### PR TITLE
feat: carousel setup wizard, nav+dots auto-insert, and slide reInit 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [1.0.2](https://github.com/rtCamp/carousel-system-interactivity-api/compare/v1.0.1...v1.0.2) (2026-02-23)
+
+
+### Bug Fixes
+
+* **demo:** 4 slides per view ([e13817c](https://github.com/rtCamp/carousel-system-interactivity-api/commit/e13817c8e49e0e071580efbf95ff4c77d677e114))
+* replace PNG images with optimized WEBP format ([eb60082](https://github.com/rtCamp/carousel-system-interactivity-api/commit/eb6008251039ea700262c63db89a266072ee6c3f))
+* replace urls with webp alts ([000f894](https://github.com/rtCamp/carousel-system-interactivity-api/commit/000f894a9818bd8181977cb038231e0ea3d82386))
+
+### Features
+
+* setup wizard styles ([0be0bf7](https://github.com/rtCamp/carousel-system-interactivity-api/commit/0be0bf7cde8c9035cca1086dce7dce005e0d39b2))
+* slide appender and setup ([a42331d](https://github.com/rtCamp/carousel-system-interactivity-api/commit/a42331d10b225379408ddf8c0649e83484496a1e))
+
+
 # [1.0.1](https://github.com/rtCamp/carousel-system-interactivity-api/compare/1.0.0...1.0.1) (2026-02-16)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carousel-kit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "carousel-kit",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@wordpress/babel-preset-default": "8.38.0",
         "@wordpress/block-editor": "^15.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carousel-kit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Carousel block using Embla and WordPress Interactivity API",
   "author": "rtCamp",
   "private": true,

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -58,8 +58,6 @@ export default function Edit( {
 
 	const { replaceInnerBlocks, insertBlock } = useDispatch( 'core/block-editor' );
 
-	// Existing carousels (before this feature) already have inner blocks;
-	// skip the setup screen for them even though isSetup is still false.
 	const hasInnerBlocks = useSelect(
 		( select ) =>
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -67,7 +65,6 @@ export default function Edit( {
 		[ clientId ],
 	);
 
-	// Find the viewport block so the carousel-level toolbar can insert slides into it.
 	const viewportClientId = useSelect(
 		( select ) => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -84,10 +81,6 @@ export default function Edit( {
 		insertBlock( createBlock( 'carousel-kit/carousel-slide' ), undefined, viewportClientId );
 	}, [ insertBlock, viewportClientId ] );
 
-	// Show the setup screen only for a genuinely fresh insertion.
-	// hasInnerBlocks alone is the reliable gate: existing carousels already have
-	// inner blocks so they skip setup; a new carousel has none until the user picks.
-	// This avoids persisting editor-only state (isSetup) into post content.
 	const showSetup = ! hasInnerBlocks;
 
 	// Fetch registered block types for the allowed-blocks token field
@@ -109,7 +102,6 @@ export default function Edit( {
 		} as React.CSSProperties,
 	} );
 
-	// No template — setup is handled via replaceInnerBlocks
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {} );
 
 	const carouselOptions = useMemo(
@@ -147,9 +139,6 @@ export default function Edit( {
 		],
 	);
 
-	/**
-	 * Controls + Dots in a flex-row group with space-between.
-	 */
 	const createNavGroup = () =>
 		createBlock(
 			'core/group',
@@ -166,9 +155,6 @@ export default function Edit( {
 			],
 		);
 
-	// Create N slides, each with a single empty paragraph.
-	// No wrapper group — avoids any persistent padding or layout constraints
-	// that would interfere with the user's own content structure.
 	const handleSetup = ( slideCount: number ) => {
 		const slides = Array.from( { length: slideCount }, () =>
 			createBlock( 'carousel-kit/carousel-slide', {}, [
@@ -194,7 +180,6 @@ export default function Edit( {
 		);
 	};
 
-	// ── Shared inspector panels ──────────────────────────────────────────────
 	const inspectorControls = (
 		<>
 			<InspectorControls>
@@ -400,7 +385,6 @@ export default function Edit( {
 		</>
 	);
 
-	// ── Setup / chooser screen ───────────────────────────────────────────────
 	if ( showSetup ) {
 		return (
 			<EditorCarouselContext.Provider value={ contextValue }>
@@ -439,7 +423,6 @@ export default function Edit( {
 		);
 	}
 
-	// ── Normal carousel editor ───────────────────────────────────────────────
 	return (
 		<EditorCarouselContext.Provider value={ contextValue }>
 			<BlockControls>

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -4,6 +4,7 @@ import {
 	useInnerBlocksProps,
 	InspectorControls,
 	InspectorAdvancedControls,
+	BlockControls,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -13,25 +14,26 @@ import {
 	BaseControl,
 	TextControl,
 	RangeControl,
+	Placeholder,
+	Button,
+	ToolbarButton,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { useState, useMemo } from '@wordpress/element';
+import { plus } from '@wordpress/icons';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useState, useMemo, useCallback } from '@wordpress/element';
+import { createBlock, type BlockConfiguration } from '@wordpress/blocks';
 import type { CarouselAttributes } from './types';
-import type { BlockConfiguration, Template } from '@wordpress/blocks';
 import { EditorCarouselContext } from './editor-context';
 import type { EmblaCarouselType } from 'embla-carousel';
-
-const TEMPLATE: Template[] = [
-	[ 'carousel-kit/carousel-viewport', {} ],
-	[ 'carousel-kit/carousel-controls', {} ],
-];
 
 export default function Edit( {
 	attributes,
 	setAttributes,
+	clientId,
 }: {
 	attributes: CarouselAttributes;
 	setAttributes: ( attrs: Partial<CarouselAttributes> ) => void;
+	clientId: string;
 } ) {
 	const {
 		loop,
@@ -54,12 +56,44 @@ export default function Edit( {
 	const [ canScrollPrev, setCanScrollPrev ] = useState( false );
 	const [ canScrollNext, setCanScrollNext ] = useState( false );
 
-	// Fetch all registered block types for suggestions
-	const blockTypes = useSelect( ( select ) => {
-		return (
+	const { replaceInnerBlocks, insertBlock } = useDispatch( 'core/block-editor' );
+
+	// Existing carousels (before this feature) already have inner blocks;
+	// skip the setup screen for them even though isSetup is still false.
+	const hasInnerBlocks = useSelect(
+		( select ) =>
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			select( 'core/blocks' ) as any
-		).getBlockTypes() as BlockConfiguration[];
+			( select( 'core/block-editor' ) as any ).getBlockCount( clientId ) > 0,
+		[ clientId ],
+	);
+
+	// Find the viewport block so the carousel-level toolbar can insert slides into it.
+	const viewportClientId = useSelect(
+		( select ) => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const innerBlocks = ( select( 'core/block-editor' ) as any ).getBlocks( clientId ) as Array<{ name: string; clientId: string }>;
+			return innerBlocks.find( ( b ) => b.name === 'carousel-kit/carousel-viewport' )?.clientId;
+		},
+		[ clientId ],
+	);
+
+	const addSlide = useCallback( () => {
+		if ( ! viewportClientId ) {
+			return;
+		}
+		insertBlock( createBlock( 'carousel-kit/carousel-slide' ), undefined, viewportClientId );
+	}, [ insertBlock, viewportClientId ] );
+
+	// Show the setup screen only for a genuinely fresh insertion.
+	// hasInnerBlocks alone is the reliable gate: existing carousels already have
+	// inner blocks so they skip setup; a new carousel has none until the user picks.
+	// This avoids persisting editor-only state (isSetup) into post content.
+	const showSetup = ! hasInnerBlocks;
+
+	// Fetch registered block types for the allowed-blocks token field
+	const blockTypes = useSelect( ( select ) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		return ( select( 'core/blocks' ) as any ).getBlockTypes() as BlockConfiguration[];
 	}, [] );
 
 	const suggestions = blockTypes?.map( ( block ) => block.name ) || [];
@@ -75,11 +109,9 @@ export default function Edit( {
 		} as React.CSSProperties,
 	} );
 
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		template: TEMPLATE,
-	} );
+	// No template — setup is handled via replaceInnerBlocks
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {} );
 
-	// Memoize carouselOptions separately to prevent excessive viewport reinitializations
 	const carouselOptions = useMemo(
 		() => ( {
 			loop,
@@ -94,8 +126,6 @@ export default function Edit( {
 		[ loop, dragFree, carouselAlign, containScroll, direction, axis, height, slidesToScroll ],
 	);
 
-	// Memoize the context value to prevent infinite re-renders in children
-	// Note: setState functions are stable and don't need to be in dependencies
 	const contextValue = useMemo(
 		() => ( {
 			emblaApi,
@@ -117,8 +147,56 @@ export default function Edit( {
 		],
 	);
 
-	return (
-		<EditorCarouselContext.Provider value={ contextValue }>
+	/**
+	 * Controls + Dots in a flex-row group with space-between.
+	 */
+	const createNavGroup = () =>
+		createBlock(
+			'core/group',
+			{
+				layout: {
+					type: 'flex',
+					flexWrap: 'nowrap',
+					justifyContent: 'space-between',
+				},
+			},
+			[
+				createBlock( 'carousel-kit/carousel-controls', {} ),
+				createBlock( 'carousel-kit/carousel-dots', {} ),
+			],
+		);
+
+	// Create N slides, each with a single empty paragraph.
+	// No wrapper group — avoids any persistent padding or layout constraints
+	// that would interfere with the user's own content structure.
+	const handleSetup = ( slideCount: number ) => {
+		const slides = Array.from( { length: slideCount }, () =>
+			createBlock( 'carousel-kit/carousel-slide', {}, [
+				createBlock( 'core/paragraph', {} ),
+			] ),
+		);
+
+		replaceInnerBlocks(
+			clientId,
+			[ createBlock( 'carousel-kit/carousel-viewport', {}, slides ), createNavGroup() ],
+			false,
+		);
+	};
+
+	/**
+	 * Skip — still creates the correct structure, just without slides.
+	 */
+	const handleSkip = () => {
+		replaceInnerBlocks(
+			clientId,
+			[ createBlock( 'carousel-kit/carousel-viewport', {} ), createNavGroup() ],
+			false,
+		);
+	};
+
+	// ── Shared inspector panels ──────────────────────────────────────────────
+	const inspectorControls = (
+		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Carousel Settings', 'carousel-kit' ) }>
 					<ToggleControl
@@ -145,9 +223,7 @@ export default function Edit( {
 							{ label: __( 'End', 'carousel-kit' ), value: 'end' },
 						] }
 						onChange={ ( value ) =>
-							setAttributes( {
-								carouselAlign: value as CarouselAttributes['carouselAlign'],
-							} )
+							setAttributes( { carouselAlign: value as CarouselAttributes[ 'carouselAlign' ] } )
 						}
 					/>
 					<SelectControl
@@ -159,9 +235,7 @@ export default function Edit( {
 							{ label: __( 'None', 'carousel-kit' ), value: '' },
 						] }
 						onChange={ ( value ) =>
-							setAttributes( {
-								containScroll: value as CarouselAttributes['containScroll'],
-							} )
+							setAttributes( { containScroll: value as CarouselAttributes[ 'containScroll' ] } )
 						}
 						help={ __(
 							'Prevents excess scrolling at the beginning or end.',
@@ -171,8 +245,13 @@ export default function Edit( {
 					<ToggleControl
 						label={ __( 'Scroll Auto', 'carousel-kit' ) }
 						checked={ slidesToScroll === 'auto' }
-						onChange={ ( isAuto ) => setAttributes( { slidesToScroll: isAuto ? 'auto' : '1' } ) }
-						help={ __( 'Scrolls the number of slides currently visible in the viewport.', 'carousel-kit' ) }
+						onChange={ ( isAuto ) =>
+							setAttributes( { slidesToScroll: isAuto ? 'auto' : '1' } )
+						}
+						help={ __(
+							'Scrolls the number of slides currently visible in the viewport.',
+							'carousel-kit',
+						) }
 					/>
 					{ slidesToScroll !== 'auto' && (
 						<RangeControl
@@ -193,9 +272,7 @@ export default function Edit( {
 							{ label: __( 'Right to Left (RTL)', 'carousel-kit' ), value: 'rtl' },
 						] }
 						onChange={ ( value ) =>
-							setAttributes( {
-								direction: value as CarouselAttributes['direction'],
-							} )
+							setAttributes( { direction: value as CarouselAttributes[ 'direction' ] } )
 						}
 						help={ __(
 							'Choose content direction. RTL is typically used for Arabic, Hebrew, and other right-to-left languages.',
@@ -210,9 +287,7 @@ export default function Edit( {
 							{ label: __( 'Vertical', 'carousel-kit' ), value: 'y' },
 						] }
 						onChange={ ( value ) =>
-							setAttributes( {
-								axis: value as CarouselAttributes['axis'],
-							} )
+							setAttributes( { axis: value as CarouselAttributes[ 'axis' ] } )
 						}
 					/>
 					{ axis === 'y' && (
@@ -322,6 +397,59 @@ export default function Edit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
+		</>
+	);
+
+	// ── Setup / chooser screen ───────────────────────────────────────────────
+	if ( showSetup ) {
+		return (
+			<EditorCarouselContext.Provider value={ contextValue }>
+				{ inspectorControls }
+				<div { ...blockProps }>
+					<Placeholder
+						icon="columns"
+						label={ __( 'Carousel', 'carousel-kit' ) }
+						instructions={ __( 'How many slides would you like to start with?', 'carousel-kit' ) }
+						className="carousel-kit-setup"
+					>
+						<div className="carousel-kit-setup__options">
+							{ [ 1, 2, 3, 4 ].map( ( count ) => (
+								<Button
+									key={ count }
+									variant="secondary"
+									className="carousel-kit-setup__option"
+									onClick={ () => handleSetup( count ) }
+								>
+									{ count === 1
+										? __( '1 Slide', 'carousel-kit' )
+										: `${ count } ${ __( 'Slides', 'carousel-kit' ) }` }
+								</Button>
+							) ) }
+						</div>
+						<Button
+							variant="link"
+							className="carousel-kit-setup__skip"
+							onClick={ handleSkip }
+						>
+							{ __( 'Skip', 'carousel-kit' ) }
+						</Button>
+					</Placeholder>
+				</div>
+			</EditorCarouselContext.Provider>
+		);
+	}
+
+	// ── Normal carousel editor ───────────────────────────────────────────────
+	return (
+		<EditorCarouselContext.Provider value={ contextValue }>
+			<BlockControls>
+				<ToolbarButton
+					icon={ plus }
+					label={ __( 'Add Slide', 'carousel-kit' ) }
+					onClick={ addSlide }
+				/>
+			</BlockControls>
+			{ inspectorControls }
 			<div { ...innerBlocksProps } />
 		</EditorCarouselContext.Provider>
 	);

--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -1,6 +1,47 @@
 /**
  * Editor-only styles for Carousel
  */
+
+// ── Setup chooser ────────────────────────────────────────────────────────────
+.carousel-kit-setup {
+	.carousel-kit-setup__options {
+		display: flex;
+		gap: 8px;
+		flex-wrap: wrap;
+		margin-bottom: 12px;
+	}
+
+	.carousel-kit-setup__option {
+		min-width: 80px;
+		justify-content: center;
+	}
+
+	.carousel-kit-setup__skip {
+		display: block;
+		margin-top: 4px;
+	}
+}
+
+// ── Viewport empty state ─────────────────────────────────────────────────────
+// Rendered via renderAppender inside .embla__container (a flex row).
+// flex: 0 0 100% makes it fill the full container width as a single flex item.
+.carousel-kit-viewport-empty {
+	flex: 0 0 100%;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding: 2rem;
+	border: 1px dashed #ccc;
+	border-radius: 2px;
+	box-sizing: border-box;
+}
+
+// Give slides a minimum visual height in the editor so they are
+// easy to click and populate. Does not affect the frontend.
+.carousel-kit .embla__slide {
+	min-height: 200px;
+}
+
 .carousel-kit {
 	/* Ensure selectable area */
 	padding: 0.625rem;

--- a/src/blocks/carousel/viewport/edit.tsx
+++ b/src/blocks/carousel/viewport/edit.tsx
@@ -34,8 +34,6 @@ export default function Edit( {
 		},
 	} );
 
-	// Track actual count — used both for the empty-state check and for triggering
-	// Embla reInit whenever the number of slides changes.
 	const slideCount = useSelect(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		( select ) => ( select( 'core/block-editor' ) as any ).getBlockCount( clientId ) as number,
@@ -54,8 +52,6 @@ export default function Edit( {
 		insertBlock( block, undefined, clientId );
 	}, [ insertBlock, clientId ] );
 
-	// Stable renderAppender for the empty state — memoized so useInnerBlocksProps
-	// doesn't see a new function reference on every render.
 	const EmptyAppender = useCallback(
 		() => (
 			<div className="carousel-kit-viewport-empty">
@@ -67,9 +63,6 @@ export default function Edit( {
 		[ addSlide ],
 	);
 
-	// No default template — slide creation is handled by the carousel setup flow.
-	// When empty, renderAppender shows the "Add Slide" button inside .embla__container
-	// (a flex container), keeping it properly contained and at full width.
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'embla__container',
@@ -86,8 +79,6 @@ export default function Edit( {
 		},
 	);
 
-	// Rerun whenever the slide count changes (slide added/removed via block inserter,
-	// toolbar, or any other mechanism) so Embla re-indexes dots and nav state.
 	useEffect( () => {
 		const api = emblaRef.current
 			? ( emblaRef.current as { [ EMBLA_KEY ]?: EmblaCarouselType } )[ EMBLA_KEY ]


### PR DESCRIPTION
  Description:                                          

  ## Summary

  - **Setup wizard on insert** — new carousels now show a `Placeholder`
    chooser asking how many slides to start with (1–4) or skip. Uses
    `replaceInnerBlocks` to build the full structure in one shot; existing
    carousels are unaffected (`hasInnerBlocks` gates the screen).

  - **Auto-insert nav + dots** — both `carousel-controls` and
    `carousel-dots` are always created together, wrapped in a `core/group`
    with `flex / nowrap / space-between` layout, so they sit side-by-side
    out of the box.

  - **Empty-state "Add Slide" button** — when the viewport has no slides,
    a primary "Add Slide" button is rendered inside `.embla__container`
    via `renderAppender` (properly contained as a flex item, no overflow).

  - **"Add Slide" toolbar on carousel block** — the parent carousel block
    now exposes an "Add Slide" toolbar button alongside the existing one on
    the viewport, by resolving the viewport `clientId` from inner blocks.

  - **Embla reInit on slide count change** — a dedicated `useEffect`
    watches the WP block store's slide count and calls `embla.reInit()`
    whenever it changes, fixing nav/dot state not updating when slides are
    added or removed via the block inserter.

  - **Editor visual scaffold** — `.embla__slide` gets `min-height: 200px`
    in `editor.scss` (editor-only, no frontend impact) so empty slides are
    easy to click and populate.

  ## Notes

  - Scaffolded slides use a bare empty `core/paragraph` with no wrapper
    group, avoiding any persistent padding that would interfere with user
    content.
  - `addSlide` and `EmptyAppender` are memoised with `useCallback` to
    prevent unnecessary re-renders of the inner blocks area.
  - `isSetup` was considered but dropped — `!hasInnerBlocks` alone is the
    correct gate and avoids polluting post content with editor-only state.