### PR TITLE
fix(editor): prevent ghost slides and state corruption when clicking between slides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.0.3](https://github.com/rtCamp/carousel-system-interactivity-api/compare/v1.0.2...v1.0.3) (2026-02-24)
+
+
+### Bug Fixes
+
+* enable loop on editor ([fe4566a](https://github.com/rtCamp/carousel-system-interactivity-api/commit/fe4566afcf72e1e663c7eb481a7957d62c2d3365))
+* state corruption when clicking between slides ([637e4a5](https://github.com/rtCamp/carousel-system-interactivity-api/commit/637e4a507eb2c58576c4004d5460e8aa7295db9f))
+
 ## [1.0.2](https://github.com/rtCamp/carousel-system-interactivity-api/compare/v1.0.1...v1.0.2) (2026-02-23)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carousel-kit",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "carousel-kit",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@wordpress/babel-preset-default": "8.38.0",
         "@wordpress/block-editor": "^15.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carousel-kit",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Carousel block using Embla and WordPress Interactivity API",
   "author": "rtCamp",
   "private": true,

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -189,7 +189,7 @@ export default function Edit( {
 						checked={ loop }
 						onChange={ ( value ) => setAttributes( { loop: value } ) }
 						help={ __(
-							'Infinite scrolling of slides (Frontend only). Disabled in editor for stability.',
+							'Enables infinite scrolling of slides.',
 							'carousel-kit',
 						) }
 					/>


### PR DESCRIPTION
## Problem

  In the block editor, clicking in the gap between slides caused two distinct bugs:

  - **Loop enabled**: slides permanently reordered and lost their transforms ("ghost slide")
  - **Loop disabled**: carousel jumped to slide 0, navigation buttons disabled, dots collapsed to one

  The issue did **not** reproduce on the frontend.

  ## Root Cause

  Embla ships with three built-in watchers that are all enabled by default:

  | Watcher | Mechanism | Editor trigger |
  |---|---|---|
  | `watchSlides` | `MutationObserver` on `.embla__container` | Gutenberg injects its block insertion-point indicator and block appender as **direct children** of `.embla__container`; Embla detected these as slide additions/removals and called `reInit()` |
  | `watchResize` | `ResizeObserver` on the viewport | Block toolbar appearing on selection causes a layout measurement that could trigger `reInit()` |
  | `watchDrag` | Pointer event listeners | Clicks in the CSS gap area started Embla's drag tracking and caused unintended scroll snapping |

  The primary culprit was `watchSlides`: after `reInit()`, Embla recalculated scroll snaps with Gutenberg's UI node counted as an extra slide, producing wrong transforms and snap positions.

  ## Fix

  Disable all three watchers in the editor's Embla initialisation (`viewport/edit.tsx`):

  ```js
  watchSlides: false,  // Gutenberg injects UI nodes into .embla__container
  watchResize: false,  // Block toolbar can cause spurious reInit
  watchDrag:   false,  // Clicks in slide gaps must not trigger scroll
  ```

Also fixed a pre-existing ESLint warning (`react-hooks/exhaustive-deps`): `emblaRef.current` was read inside the effect cleanup function. It is now captured into a stable `viewportEl` variable at effect mount time.