### PR TITLE
[Fix]: remove unnecessary grid-template-columns property

### DIFF
--- a/src/blocks/carousel/styles/_core.scss
+++ b/src/blocks/carousel/styles/_core.scss
@@ -17,7 +17,6 @@
 	margin: 0;
 	padding: 0;
 	list-style: none;
-	grid-template-columns: none;
 	gap: var(--carousel-kit-gap, 0);
 }
 


### PR DESCRIPTION
Description: Removed unnecessary CSS styles.

Issue: https://github.com/rtCamp/carousel-kit/issues/65