### PR TITLE
[Refactor]: CSS Cleanup & Dot Animation Improvements

### DIFF
--- a/src/blocks/carousel/controls/style.scss
+++ b/src/blocks/carousel/controls/style.scss
@@ -22,15 +22,15 @@
 	height: var(--carousel-kit-control-size, 2.5rem);
 }
 
+.carousel-kit-controls__btn:disabled {
+	cursor: not-allowed;
+	opacity: 0.25;
+}
+
 .carousel-kit-controls__btn:not(:disabled):hover {
 	background-color: var(--carousel-kit-control-bg-hover, rgba(248, 248, 248, 1));
 	border: var(--carousel-kit-control-border-hover, 1.25px solid rgba(28, 28, 28, 0.75));
 	color: var(--carousel-kit-control-color-hover, inherit);
-}
-
-.carousel-kit-controls__btn:disabled {
-	cursor: not-allowed;
-	opacity: 0.25;
 }
 
 // In RTL mode, rotate the icons 180 degrees to flip their direction

--- a/src/blocks/carousel/dots/style.scss
+++ b/src/blocks/carousel/dots/style.scss
@@ -15,11 +15,10 @@
 	border: var(--carousel-kit-dot-border, none);
 	cursor: pointer;
 	padding: 0;
-	transition: all 0.2s ease;
+	transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .carousel-kit-dot.is-active {
 	background-color: var(--carousel-kit-dot-active-color, rgba(28, 28, 28, 1));
-	width: var(--carousel-kit-dot-active-size, 0.75rem);
-	height: var(--carousel-kit-dot-active-size, 0.75rem);
+	transform: scale(var(--carousel-kit-dot-active-scale, 1.5));
 }

--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -4,6 +4,7 @@
 
 // ── Setup chooser ────────────────────────────────────────────────────────────
 .carousel-kit-setup {
+
 	.carousel-kit-setup__options {
 		display: flex;
 		gap: 8px;
@@ -43,6 +44,7 @@
 }
 
 .carousel-kit {
+
 	/* Ensure selectable area */
 	padding: 0.625rem;
 	border: 1px dashed #ccc;

--- a/src/blocks/carousel/styles/_core.scss
+++ b/src/blocks/carousel/styles/_core.scss
@@ -30,9 +30,7 @@
 /* Force slides (including posts) to respect a configurable width variable */
 :where(.carousel-kit) .embla__slide,
 :where(.carousel-kit) .embla .wp-block-post-template li {
-	display: block;
 	flex: 0 0 var(--carousel-kit-slide-width, 100%);
-	width: var(--carousel-kit-slide-width, 100%);
 	max-width: var(--carousel-kit-slide-width, 100%);
 	min-width: 0;
 	box-sizing: border-box;
@@ -59,11 +57,6 @@
 }
 
 /* Vertical Axis adjustments */
-:where(.carousel-kit[data-axis="y"]) {
-	display: flex;
-	flex-direction: column;
-}
-
 :where(.carousel-kit[data-axis="y"]) .embla {
 	height: var(--carousel-kit-height);
 }
@@ -76,9 +69,6 @@
 
 :where(.carousel-kit[data-axis="y"]) .embla__slide,
 :where(.carousel-kit[data-axis="y"]) .embla .wp-block-post-template li {
-	flex: 0 0 var(--carousel-kit-slide-width, 100%);
-	width: 100%;
-	max-width: 100%;
 	margin-inline-end: 0;
 }
 

--- a/src/blocks/carousel/styles/_core.scss
+++ b/src/blocks/carousel/styles/_core.scss
@@ -74,9 +74,6 @@
 
 /* Vertical + Loop specific */
 :where(.carousel-kit[data-axis="y"][data-loop="true"]) .embla__slide,
-:where(.carousel-kit[data-axis="y"][data-loop="true"])
-	.embla
-	.wp-block-post-template
-	li {
+:where(.carousel-kit[data-axis="y"][data-loop="true"]) .embla .wp-block-post-template li {
 	margin-block-end: var(--carousel-kit-gap, 0);
 }


### PR DESCRIPTION
## CSS Cleanup & Dot Animation Improvements

### Changes

- Dots: Use explicit transitions (`background-color`, `transform`) instead of `all`
- Dots: Switch active dot sizing to `transform: scale()` for smoother, layout-stable animation
- Dots: Add `--carousel-kit-dot-active-scale` CSS variable for external customization
- Core: Remove ineffective `flex-direction: column` (parent lacks `display: flex`)
- Core: Remove redundant `flex` declaration in vertical axis slide rules

### Why

- Improves animation performance (compositor-friendly transforms)
- Removes dead/redundant CSS
- Maintains customization options via CSS variables

### Issue:
https://github.com/rtCamp/carousel-kit/issues/66