### PR TITLE
[Fix]: Add direct access protection to example pattern files

### DIFF
--- a/examples/patterns/hero-carousel.php
+++ b/examples/patterns/hero-carousel.php
@@ -6,6 +6,11 @@
  * Description: A full-width hero carousel with large images and overlaid text
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 $pattern_images_url = trailingslashit( CAROUSEL_KIT_URL . '/examples/data/images' );
 $hero_slide_one     = $pattern_images_url . 'slide-autoplay-1.webp';
 $hero_slide_two     = $pattern_images_url . 'slide-autoplay-2.webp';

--- a/examples/patterns/logo-showcase.php
+++ b/examples/patterns/logo-showcase.php
@@ -6,6 +6,11 @@
  * Description: Display partner or client logos in a continuous carousel
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 $pattern_images_url = trailingslashit( CAROUSEL_KIT_URL . '/examples/data/images' );
 $logo_one           = $pattern_images_url . 'logo-placeholder-1.svg';
 $logo_two           = $pattern_images_url . 'logo-placeholder-2.svg';

--- a/examples/patterns/query-loop.php
+++ b/examples/patterns/query-loop.php
@@ -5,6 +5,11 @@
  * Categories: carousel-kit
  * Description: A carousel block containing a query loop displaying posts in a grid layout.
  */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <!-- wp:carousel-kit/carousel {"ariaLabel":"Carousel Kit: Query Loop Carousel","slideGap":16,"metadata":{"name":"Carousel Kit: Query Loop Carousel","categories":["carousel-kit"],"patternName":"carousel-kit/query-loop-carousel"},"align":"wide","className":"wp-block-carousel-carousel is-style-default"} -->

--- a/examples/patterns/testimonial-carousel.php
+++ b/examples/patterns/testimonial-carousel.php
@@ -5,6 +5,11 @@
  * Categories: carousel-kit
  * Description: Customer testimonials with centered alignment and quotes
  */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <!-- wp:carousel-kit/carousel {"loop":true,"carouselAlign":"center","autoplay":true,"ariaLabel":"Customer Testimonials","slideGap":32,"metadata":{"categories":["carousel-kit"],"patternName":"carousel-kit/testimonial-carousel","name":"Carousel Kit: Testimonial Carousel"},"className":"wp-block-carousel-carousel"} -->


### PR DESCRIPTION
## Description: 
Added direct access protection to example pattern files suggested by the official plugin check recommendation


## Screenshot: 
<img width="1494" height="669" alt="image" src="https://github.com/user-attachments/assets/b9d38d46-7b3f-456d-b8d2-474d30c98fa2" />