### PR TITLE
fix: add initialized state to CarouselContext to track carousel initialization

### DIFF
--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -43,4 +43,5 @@ export type CarouselContext = {
 	canScrollNext: boolean;
 	ariaLabelPattern: string;
 	ref?: HTMLElement | null;
+	initialized?: boolean; // Internal state to track if the carousel has been initialized. See: https://github.com/rtCamp/carousel-kit/issues/78
 };

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -122,8 +122,7 @@ store( 'carousel-kit/carousel', {
 			if ( index === -1 ) {
 				return false;
 			}
-			const { selectedIndex } = getContext<CarouselContext>();
-			return selectedIndex === index;
+			return context.selectedIndex === index;
 		},
 		isDotActive: () => {
 			const context = getContext<CarouselContext>();

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -95,6 +95,13 @@ store( 'carousel-kit/carousel', {
 	},
 	callbacks: {
 		isSlideActive: () => {
+			// Track initialization state to prevent errors when Embla isn't ready
+			// See: https://github.com/rtCamp/carousel-kit/issues/78
+			const context = getContext<CarouselContext>();
+			if ( ! context.initialized ) {
+				return false;
+			}
+
 			// Check for either standard slide or Query Loop post
 			const slide = getElementRef( getElement() )?.closest?.(
 				'.embla__slide, .wp-block-post',
@@ -214,6 +221,7 @@ store( 'carousel-kit/carousel', {
 					viewport[ EMBLA_KEY ] = embla;
 
 					const updateState = () => {
+						context.initialized = true;
 						context.canScrollPrev = embla.canScrollPrev();
 						context.canScrollNext = embla.canScrollNext();
 						context.selectedIndex = embla.selectedScrollSnap();


### PR DESCRIPTION
## Summary

This PR updates `aria-current="true"` for the slides as well when it changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

<!-- 'Closes' will automatically close the linked issue when this PR is merged. -->
<!-- 'Relates to' is for issues that are relevant but won't be closed by this PR. -->
Closes #78

## What changed

Added an internal flag to check for the Embla initialization before `isSlideActive` callback. 

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
