### PR TITLE
[Chore]: Exclude composer.json and composer.lock from distribution package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,6 @@ dist:
 		--exclude='package-lock.json' \
 		--exclude='blueprint.json' \
 		--exclude='tsconfig.json' \
-		--exclude='composer.json' \
-		--exclude='composer.lock' \
 		--exclude='Makefile' \
 		--exclude='CHANGELOG.md' \
 		--exclude='DEVELOPMENT.md' \


### PR DESCRIPTION
## Summary

This PR will exclude composer.json and composer.lock from the distribution package as WP.org plugin team suggested

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [x] Build/CI/tooling

## Related issue(s)

<!-- 'Closes' will automatically close the linked issue when this PR is merged. -->
<!-- 'Relates to' is for issues that are relevant but won't be closed by this PR. -->
Closes #<issue-number>
Relates to #[<issue-number> (1257)
](https://github.com/rtCamp/marketing/issues/1257)
## What changed

- Makefile: Exclude composer.json and composer.lock from the distribution package

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [ ] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
