### PR TITLE
Fix[Controls]: Block Toolbar persists when selected block moves out of view in carousel

### DIFF
--- a/src/blocks/carousel/controls/edit.tsx
+++ b/src/blocks/carousel/controls/edit.tsx
@@ -1,14 +1,15 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useContext, useRef } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { EditorCarouselContext } from '../editor-context';
 import { NextIcon, PreviousIcon } from './components/icons';
 import type { EmblaCarouselType } from 'embla-carousel';
+import type { BlockEditorSelectors } from '../types';
 
 const EMBLA_KEY = Symbol.for( 'carousel-system.carousel' );
 
-export default function Edit() {
+export default function Edit( { clientId } : { clientId: string } ) {
 	const {
 		emblaApi: contextApi,
 		canScrollPrev,
@@ -17,6 +18,31 @@ export default function Edit() {
 	const ref = useRef<HTMLDivElement>( null );
 
 	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
+
+	/**
+	 * Clear block selection when navigating slides, but only if the selected block
+	 * belongs to this carousel — avoids disrupting selections outside it.
+	 */
+	const shouldClearSelection = useSelect( ( select ) => {
+		const store = select( 'core/block-editor' ) as BlockEditorSelectors;
+
+		const selectedId = store.getSelectedBlockClientId();
+		if ( ! selectedId ) {
+			return false;
+		}
+
+		const carouselClientId = store.getBlockParentsByBlockName(
+			clientId,
+			'carousel-kit/carousel',
+		)?.[ 0 ];
+
+		if ( ! carouselClientId ) {
+			return false;
+		}
+
+		const parents = store.getBlockParents( selectedId );
+		return parents.includes( carouselClientId );
+	}, [ clientId ] );
 
 	const blockProps = useBlockProps( {
 		className: 'carousel-kit-controls',
@@ -50,7 +76,9 @@ export default function Edit() {
 			api.scrollNext();
 		}
 
-		clearSelectedBlock();
+		if ( shouldClearSelection ) {
+			clearSelectedBlock();
+		}
 	};
 
 	return (

--- a/src/blocks/carousel/controls/edit.tsx
+++ b/src/blocks/carousel/controls/edit.tsx
@@ -1,6 +1,7 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useContext, useRef } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
 import { EditorCarouselContext } from '../editor-context';
 import { NextIcon, PreviousIcon } from './components/icons';
 import type { EmblaCarouselType } from 'embla-carousel';
@@ -14,6 +15,8 @@ export default function Edit() {
 		canScrollNext,
 	} = useContext( EditorCarouselContext );
 	const ref = useRef<HTMLDivElement>( null );
+
+	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
 
 	const blockProps = useBlockProps( {
 		className: 'carousel-kit-controls',
@@ -37,13 +40,17 @@ export default function Edit() {
 
 	const handleScroll = ( direction: 'prev' | 'next' ) => {
 		const api = contextApi || getEmblaFromDOM();
-		if ( api ) {
-			if ( direction === 'prev' ) {
-				api.scrollPrev();
-			} else {
-				api.scrollNext();
-			}
+		if ( ! api ) {
+			return;
 		}
+
+		if ( direction === 'prev' ) {
+			api.scrollPrev();
+		} else {
+			api.scrollNext();
+		}
+
+		clearSelectedBlock();
 	};
 
 	return (

--- a/src/blocks/carousel/controls/edit.tsx
+++ b/src/blocks/carousel/controls/edit.tsx
@@ -1,15 +1,14 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useContext, useRef } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { EditorCarouselContext } from '../editor-context';
 import { NextIcon, PreviousIcon } from './components/icons';
 import type { EmblaCarouselType } from 'embla-carousel';
-import type { BlockEditorSelectors } from '../types';
+import { useMergeRefs } from '@wordpress/compose';
 
 const EMBLA_KEY = Symbol.for( 'carousel-system.carousel' );
 
-export default function Edit( { clientId } : { clientId: string } ) {
+export default function Edit() {
 	const {
 		emblaApi: contextApi,
 		canScrollPrev,
@@ -17,36 +16,11 @@ export default function Edit( { clientId } : { clientId: string } ) {
 	} = useContext( EditorCarouselContext );
 	const ref = useRef<HTMLDivElement>( null );
 
-	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
-
-	/**
-	 * Clear block selection when navigating slides, but only if the selected block
-	 * belongs to this carousel — avoids disrupting selections outside it.
-	 */
-	const shouldClearSelection = useSelect( ( select ) => {
-		const store = select( 'core/block-editor' ) as BlockEditorSelectors;
-
-		const selectedId = store.getSelectedBlockClientId();
-		if ( ! selectedId ) {
-			return false;
-		}
-
-		const carouselClientId = store.getBlockParentsByBlockName(
-			clientId,
-			'carousel-kit/carousel',
-		)?.[ 0 ];
-
-		if ( ! carouselClientId ) {
-			return false;
-		}
-
-		const parents = store.getBlockParents( selectedId );
-		return parents.includes( carouselClientId );
-	}, [ clientId ] );
-
 	const blockProps = useBlockProps( {
 		className: 'carousel-kit-controls',
 	} );
+
+	const mergedRef = useMergeRefs( [ blockProps.ref, ref ] );
 
 	const getEmblaFromDOM = () => {
 		if ( ! ref.current ) {
@@ -66,23 +40,17 @@ export default function Edit( { clientId } : { clientId: string } ) {
 
 	const handleScroll = ( direction: 'prev' | 'next' ) => {
 		const api = contextApi || getEmblaFromDOM();
-		if ( ! api ) {
-			return;
-		}
-
-		if ( direction === 'prev' ) {
-			api.scrollPrev();
-		} else {
-			api.scrollNext();
-		}
-
-		if ( shouldClearSelection ) {
-			clearSelectedBlock();
+		if ( api ) {
+			if ( direction === 'prev' ) {
+				api.scrollPrev();
+			} else {
+				api.scrollNext();
+			}
 		}
 	};
 
 	return (
-		<div { ...blockProps } ref={ ref }>
+		<div { ...blockProps } ref={ mergedRef }>
 			<button
 				className="carousel-kit-controls__btn carousel-kit-controls__btn--prev"
 				onClick={ ( e ) => {

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -35,7 +35,6 @@ export interface BlockEditorSelectors {
 	getBlocks: ( clientId: string ) => Array<{ clientId: string }>;
 	getSelectedBlockClientId: () => string | null;
 	getBlockParents: ( clientId: string ) => string[];
-	getBlockParentsByBlockName: ( clientId: string, blockName: string | string[], ascending?: boolean ) => string[];
 }
 
 export type CarouselContext = {

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -35,6 +35,7 @@ export interface BlockEditorSelectors {
 	getBlocks: ( clientId: string ) => Array<{ clientId: string }>;
 	getSelectedBlockClientId: () => string | null;
 	getBlockParents: ( clientId: string ) => string[];
+	getBlockParentsByBlockName: ( clientId: string, blockName: string | string[], ascending?: boolean ) => string[];
 }
 
 export type CarouselContext = {


### PR DESCRIPTION
## Summary

Fixes an issue where the block toolbar persists even after the selected block moves out of the visible viewport when navigating carousel slides in the editor. This improves UI consistency by ensuring the toolbar only appears for visible, actively selected blocks.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

Closes #106 

## What changed

- The `blockProps.ref` was previously silently discarded. This PR merges the `blockProps.ref` with the existing refs. This updates the block toolbar correctly on interacting with the controls, fixing the original issue.
- As the ref is updated correctly, things like "scrolling into view" from the list view now work as intended for the control block.

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [x] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

https://github.com/user-attachments/assets/9f8a66ec-f2e8-47ec-b9c2-c5d5be867977

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added/updated tests where needed
- [x] I have updated docs where needed
- [x] I have checked for breaking changes
