### PR TITLE
Add a11y announcements for carousel slide changes

### DIFF
--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -336,7 +336,9 @@ describe( 'Carousel View Module', () => {
 
 				setEmblaOnViewport( viewport, mockEmbla );
 
-				const mockContext = createMockContext();
+				const mockContext = createMockContext( {
+					selectedIndex: 1,
+				} );
 				( mockContext as CarouselContext & { snap?: { index: number } } ).snap = {
 					index: 0,
 				};
@@ -697,6 +699,7 @@ describe( 'Carousel View Module', () => {
 
 			it( 'should update announcement after a manual slide change', () => {
 				const mockContext = createMockContext( {
+					announcementPattern: 'Slide {{currentSlide}} of {{totalSlides}}',
 					selectedIndex: -1,
 				} );
 				const { wrapper, viewport } = createMockCarouselDOM();
@@ -748,6 +751,7 @@ describe( 'Carousel View Module', () => {
 					listeners.select?.();
 
 					expect( mockContext.announcement ).toBe( 'Slide 2 of 5' );
+					expect( mockContext.shouldAnnounce ).toBe( false );
 				} finally {
 					( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver =
 						originalIntersectionObserver;

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -694,6 +694,65 @@ describe( 'Carousel View Module', () => {
 
 				consoleErrorSpy.mockRestore();
 			} );
+
+			it( 'should update announcement after a manual slide change', () => {
+				const mockContext = createMockContext( {
+					selectedIndex: -1,
+				} );
+				const { wrapper, viewport } = createMockCarouselDOM();
+				const listeners: {
+					select?: () => void;
+				} = {};
+				const selectedScrollSnap = jest
+					.fn()
+					.mockReturnValueOnce( 0 )
+					.mockReturnValueOnce( 1 );
+				const mockEmbla = createMockEmblaInstance( {
+					selectedScrollSnap,
+					scrollSnapList: jest.fn( () => [ 0, 1, 2, 3, 4 ] ),
+					slideNodes: jest.fn( () =>
+						Array.from( { length: 5 }, () => document.createElement( 'div' ) ),
+					),
+					scrollProgress: jest.fn( () => 0.25 ),
+				} );
+				const originalIntersectionObserver = window.IntersectionObserver;
+
+				mockEmbla.on = jest.fn( ( eventName: string, callback: () => void ) => {
+					if ( eventName === 'select' ) {
+						listeners.select = callback;
+					}
+					return mockEmbla;
+				} );
+
+				viewport.getBoundingClientRect = jest.fn( () => ( {
+					width: 100,
+					height: 0,
+					top: 0,
+					right: 0,
+					bottom: 0,
+					left: 0,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) );
+
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: wrapper } );
+				( EmblaCarousel as unknown as jest.Mock ).mockReturnValue( mockEmbla );
+				delete ( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver;
+
+				try {
+					storeConfig.callbacks.initCarousel();
+
+					mockContext.shouldAnnounce = true;
+					listeners.select?.();
+
+					expect( mockContext.announcement ).toBe( 'Slide 2 of 5' );
+				} finally {
+					( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver =
+						originalIntersectionObserver;
+				}
+			} );
 		} );
 	} );
 } );

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -52,6 +52,13 @@ export default function Save( {
 		slideCount: 0,
 		/* translators: %d: slide number */
 		ariaLabelPattern: __( 'Go to slide %d', 'rt-carousel' ),
+		announcement: '',
+		shouldAnnounce: false,
+		/* translators: {{currentSlide}}: current slide number, {{totalSlides}}: total slide count. */
+		announcementPattern: __(
+			'Slide {{currentSlide}} of {{totalSlides}}',
+			'rt-carousel',
+		),
 	};
 
 	const blockProps = useBlockProps.save( {
@@ -71,7 +78,26 @@ export default function Save( {
 		} as React.CSSProperties,
 	} );
 
-	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps ) as ReturnType<
+		typeof useInnerBlocksProps.save
+	> & {
+		children: React.ReactNode;
+	};
+	const { children, ...wrapperProps } = innerBlocksProps;
+	const announcementLiveRegion = (
+		<span
+			className="screen-reader-text"
+			role="status"
+			aria-live="polite"
+			aria-atomic="true"
+			data-wp-text="context.announcement"
+		/>
+	);
 
-	return <div { ...innerBlocksProps } />;
+	return (
+		<div { ...wrapperProps }>
+			{ children }
+			{ announcementLiveRegion }
+		</div>
+	);
 }

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -57,6 +57,9 @@ export type CarouselContext = {
 	canScrollNext: boolean;
 	scrollProgress: number;
 	ariaLabelPattern: string;
+	announcement?: string;
+	announcementPattern?: string;
+	shouldAnnounce?: boolean;
 	ref?: HTMLElement | null;
 	slideCount: number;
 	initialized?: boolean;

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -56,6 +56,42 @@ const getProgress = (): number => {
 	return Math.max( 0, Math.min( 1, scrollProgress || 0 ) );
 };
 
+const getSlideAnnouncement = (
+	context: CarouselContext,
+	selectedIndex: number,
+	slideCount: number,
+): string => {
+	if ( ! slideCount || slideCount <= 1 ) {
+		return '';
+	}
+	return ( context.announcementPattern || 'Slide {{currentSlide}} of {{totalSlides}}' )
+		.replace( '{{currentSlide}}', ( selectedIndex + 1 ).toString() )
+		.replace( '{{totalSlides}}', slideCount.toString() );
+};
+
+const updateSlideAnnouncement = (
+	context: CarouselContext,
+	previousSelectedIndex: number,
+): void => {
+	if ( ! context.shouldAnnounce ) {
+		return;
+	}
+
+	if ( context.selectedIndex !== previousSelectedIndex ) {
+		context.announcement = getSlideAnnouncement(
+			context,
+			context.selectedIndex,
+			context.slideCount,
+		);
+	}
+
+	context.shouldAnnounce = false;
+};
+
+const markForAnnouncement = (): void => {
+	getContext<CarouselContext>().shouldAnnounce = true;
+};
+
 store( 'rt-carousel/carousel', {
 	state: {
 		get canScrollPrev() {
@@ -72,6 +108,7 @@ store( 'rt-carousel/carousel', {
 			const element = getElementRef( getElement() );
 			const embla = getEmblaFromElement( element );
 			if ( embla ) {
+				markForAnnouncement();
 				embla.scrollPrev();
 			} else {
 				// eslint-disable-next-line no-console
@@ -82,6 +119,7 @@ store( 'rt-carousel/carousel', {
 			const element = getElementRef( getElement() );
 			const embla = getEmblaFromElement( element );
 			if ( embla ) {
+				markForAnnouncement();
 				embla.scrollNext();
 			} else {
 				// eslint-disable-next-line no-console
@@ -98,6 +136,7 @@ store( 'rt-carousel/carousel', {
 				const element = getElementRef( getElement() );
 				const embla = getEmblaFromElement( element );
 				if ( embla ) {
+					markForAnnouncement();
 					embla.scrollTo( snap.index );
 				}
 			}
@@ -237,6 +276,7 @@ store( 'rt-carousel/carousel', {
 					viewport[ EMBLA_KEY ] = embla;
 
 					const updateState = () => {
+						const previousSelectedIndex = context.selectedIndex;
 						context.initialized = true;
 						context.canScrollPrev = embla.canScrollPrev();
 						context.canScrollNext = embla.canScrollNext();
@@ -246,6 +286,7 @@ store( 'rt-carousel/carousel', {
 							.map( ( _, index ) => ( { index } ) );
 						context.scrollProgress = embla.scrollProgress();
 						context.slideCount = embla.slideNodes().length;
+						updateSlideAnnouncement( context, previousSelectedIndex );
 					};
 
 					embla.on( 'select', updateState );

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -61,10 +61,10 @@ const getSlideAnnouncement = (
 	selectedIndex: number,
 	slideCount: number,
 ): string => {
-	if ( ! slideCount || slideCount <= 1 ) {
+	if ( ! slideCount || slideCount <= 1 || ! context.announcementPattern ) {
 		return '';
 	}
-	return ( context.announcementPattern || 'Slide {{currentSlide}} of {{totalSlides}}' )
+	return context.announcementPattern
 		.replace( '{{currentSlide}}', ( selectedIndex + 1 ).toString() )
 		.replace( '{{totalSlides}}', slideCount.toString() );
 };
@@ -108,7 +108,9 @@ store( 'rt-carousel/carousel', {
 			const element = getElementRef( getElement() );
 			const embla = getEmblaFromElement( element );
 			if ( embla ) {
-				markForAnnouncement();
+				if ( embla.canScrollPrev() ) {
+					markForAnnouncement();
+				}
 				embla.scrollPrev();
 			} else {
 				// eslint-disable-next-line no-console
@@ -119,7 +121,9 @@ store( 'rt-carousel/carousel', {
 			const element = getElementRef( getElement() );
 			const embla = getEmblaFromElement( element );
 			if ( embla ) {
-				markForAnnouncement();
+				if ( embla.canScrollNext() ) {
+					markForAnnouncement();
+				}
 				embla.scrollNext();
 			} else {
 				// eslint-disable-next-line no-console
@@ -136,7 +140,9 @@ store( 'rt-carousel/carousel', {
 				const element = getElementRef( getElement() );
 				const embla = getEmblaFromElement( element );
 				if ( embla ) {
-					markForAnnouncement();
+					if ( snap.index !== context.selectedIndex ) {
+						markForAnnouncement();
+					}
 					embla.scrollTo( snap.index );
 				}
 			}


### PR DESCRIPTION
## Summary

Adds screen reader announcements when the active carousel slide changes through manual navigation. This is needed so users of assistive technologies are informed when previous/next controls or pagination dots move to a different slide.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Enhancement/refactor
- [ ] Documentation update
- [x] Test update
- [ ] Build/CI/tooling

## Related issue(s)

<!-- 'Closes' will automatically close the linked issue when this PR is merged. -->
<!-- 'Relates to' is for issues that are relevant but won't be closed by this PR. -->
Closes #124


## What changed

- Added a hidden live region to the carousel save markup for screen reader announcements.
- Updated the frontend carousel state to announce the current slide position on manual slide changes only.
- Added a regression test covering the announcement update flow.
- Prevented screen reader announcements for `autoplay-driven slide changes` so autoplay does not repeatedly interrupt screen reader users.

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [x] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

- Ran `npm run test:js -- src/blocks/carousel/__tests__/view.test.ts`
- Ran `npm run build`
- Manually verified that slide changes from previous/next buttons and dots update the screen reader announcement text

## Screenshots / recordings

https://github.com/user-attachments/assets/b115bbad-1bf1-42db-8762-41e9f14753ee



## Checklist

- [x] I have self-reviewed this PR
- [x] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
