### PR TITLE
Fix carousel dot focus loss with VoiceOver activation

### DIFF
--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -237,14 +237,15 @@ store( 'rt-carousel/carousel', {
 					viewport[ EMBLA_KEY ] = embla;
 
 					const updateState = () => {
+						const scrollSnapList = embla.scrollSnapList();
 						context.initialized = true;
 						context.canScrollPrev = embla.canScrollPrev();
 						context.canScrollNext = embla.canScrollNext();
 						context.selectedIndex = embla.selectedScrollSnap();
-						if ( context.scrollSnaps.length !== embla.scrollSnapList().length ) {
-							context.scrollSnaps = embla
-								.scrollSnapList()
-								.map( ( _, index ) => ( { index } ) );
+						if ( context.scrollSnaps.length !== scrollSnapList.length ) {
+							context.scrollSnaps = scrollSnapList.map( ( _, index ) => ( {
+								index,
+							} ) );
 						}
 						context.scrollProgress = embla.scrollProgress();
 						context.slideCount = embla.slideNodes().length;

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -241,9 +241,11 @@ store( 'rt-carousel/carousel', {
 						context.canScrollPrev = embla.canScrollPrev();
 						context.canScrollNext = embla.canScrollNext();
 						context.selectedIndex = embla.selectedScrollSnap();
-						context.scrollSnaps = embla
-							.scrollSnapList()
-							.map( ( _, index ) => ( { index } ) );
+						if ( context.scrollSnaps.length !== embla.scrollSnapList().length ) {
+							context.scrollSnaps = embla
+								.scrollSnapList()
+								.map( ( _, index ) => ( { index } ) );
+						}
 						context.scrollProgress = embla.scrollProgress();
 						context.slideCount = embla.slideNodes().length;
 					};


### PR DESCRIPTION
## Summary

Fixes an accessibility issue where carousel pagination dots lose focus after being activated with VoiceOver keyboard interaction. The dot list is now preserved when the scroll snap count has not changed, preventing unnecessary re-rendering of the focused dot element.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

Closes #126

## What changed

- Prevented `context.scrollSnaps` from being recreated on every carousel selection.
- Kept pagination dot elements stable when the scroll snap count remains the same.
- Preserved keyboard/screen-reader focus after activating a carousel dot.

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path:
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

- Added a carousel with pagination dots on the frontend.
- Enabled VoiceOver on macOS.
- Navigated to a carousel pagination dot using keyboard navigation.
- Activated the focused dot using `Control + Option + Space`.
- Verified focus remains on the activated pagination dot after the slide changes.

## Screenshots / recordings


https://github.com/user-attachments/assets/7bf326bf-24b1-4f23-90f3-750872542d72



## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
