### PR TITLE
Fix: Replace automatic plugin deactivation with admin notice

### DIFF
--- a/examples/patterns/hero-carousel.php
+++ b/examples/patterns/hero-carousel.php
@@ -11,18 +11,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$pattern_images_url = trailingslashit( RT_CAROUSEL_URL . '/examples/data/images' );
-$hero_slide_one     = $pattern_images_url . 'slide-autoplay-1.webp';
-$hero_slide_two     = $pattern_images_url . 'slide-autoplay-2.webp';
-$hero_slide_three   = $pattern_images_url . 'slide-autoplay-3.webp';
+$rt_carousel_images_url  = trailingslashit( RT_CAROUSEL_URL . '/examples/data/images' );
+$rt_carousel_slide_one   = $rt_carousel_images_url . 'slide-autoplay-1.webp';
+$rt_carousel_slide_two   = $rt_carousel_images_url . 'slide-autoplay-2.webp';
+$rt_carousel_slide_three = $rt_carousel_images_url . 'slide-autoplay-3.webp';
 ?>
 
 <!-- wp:rt-carousel/carousel {"loop":true,"autoplay":true,"autoplayDelay":5000,"ariaLabel":"Hero Carousel","metadata":{"categories":["rt-carousel"],"patternName":"rt-carousel/hero-carousel","name":"rtCarousel: Hero Carousel"},"align":"wide","className":"wp-block-carousel-carousel"} -->
 <div class="wp-block-rt-carousel-carousel alignwide rt-carousel wp-block-carousel-carousel" role="region" aria-roledescription="carousel" aria-label="Hero Carousel" dir="ltr" data-axis="x" data-loop="true" data-wp-interactive="rt-carousel/carousel" data-wp-context="{&quot;options&quot;:{&quot;loop&quot;:true,&quot;dragFree&quot;:false,&quot;align&quot;:&quot;start&quot;,&quot;containScroll&quot;:&quot;trimSnaps&quot;,&quot;direction&quot;:&quot;ltr&quot;,&quot;axis&quot;:&quot;x&quot;,&quot;slidesToScroll&quot;:1},&quot;autoplay&quot;:{&quot;delay&quot;:5000,&quot;stopOnInteraction&quot;:true,&quot;stopOnMouseEnter&quot;:false},&quot;isPlaying&quot;:true,&quot;timerIterationId&quot;:0,&quot;selectedIndex&quot;:-1,&quot;scrollSnaps&quot;:[],&quot;canScrollPrev&quot;:false,&quot;canScrollNext&quot;:false,&quot;scrollProgress&quot;:0,&quot;slideCount&quot;:0,&quot;ariaLabelPattern&quot;:&quot;Go to slide %d&quot;}" data-wp-init="callbacks.initCarousel" style="--rt-carousel-gap:0px"><!-- wp:rt-carousel/carousel-viewport {"className":"wp-block-carousel-carousel-viewport"} -->
 	<div class="wp-block-rt-carousel-carousel-viewport embla wp-block-carousel-carousel-viewport">
 		<div class="embla__container"><!-- wp:rt-carousel/carousel-slide {"className":"wp-block-carousel-carousel-slide"} -->
-			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:cover {"url":"<?php echo esc_url( $hero_slide_one ); ?>","dimRatio":30,"minHeight":600,"minHeightUnit":"px"} -->
-				<div class="wp-block-cover" style="min-height:600px"><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( $hero_slide_one ); ?>" data-object-fit="cover" /><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span>
+			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:cover {"url":"<?php echo esc_url( $rt_carousel_slide_one ); ?>","dimRatio":30,"minHeight":600,"minHeightUnit":"px"} -->
+				<div class="wp-block-cover" style="min-height:600px"><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( $rt_carousel_slide_one ); ?>" data-object-fit="cover" /><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span>
 					<div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":1,"textColor":"white"} -->
 						<h1 class="wp-block-heading has-text-align-center has-white-color has-text-color">Welcome to Our Site</h1>
 						<!-- /wp:heading -->
@@ -44,8 +44,8 @@ $hero_slide_three   = $pattern_images_url . 'slide-autoplay-3.webp';
 			<!-- /wp:rt-carousel/carousel-slide -->
 
 			<!-- wp:rt-carousel/carousel-slide {"className":"wp-block-carousel-carousel-slide"} -->
-			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:cover {"url":"<?php echo esc_url( $hero_slide_two ); ?>","dimRatio":30,"minHeight":600,"minHeightUnit":"px"} -->
-				<div class="wp-block-cover" style="min-height:600px"><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( $hero_slide_two ); ?>" data-object-fit="cover" /><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span>
+			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:cover {"url":"<?php echo esc_url( $rt_carousel_slide_two ); ?>","dimRatio":30,"minHeight":600,"minHeightUnit":"px"} -->
+				<div class="wp-block-cover" style="min-height:600px"><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( $rt_carousel_slide_two ); ?>" data-object-fit="cover" /><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span>
 					<div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":1,"textColor":"white"} -->
 						<h1 class="wp-block-heading has-text-align-center has-white-color has-text-color">Build Something Amazing</h1>
 						<!-- /wp:heading -->
@@ -60,8 +60,8 @@ $hero_slide_three   = $pattern_images_url . 'slide-autoplay-3.webp';
 			<!-- /wp:rt-carousel/carousel-slide -->
 
 			<!-- wp:rt-carousel/carousel-slide {"className":"wp-block-carousel-carousel-slide"} -->
-			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:cover {"url":"<?php echo esc_url( $hero_slide_three ); ?>","dimRatio":30,"minHeight":600,"minHeightUnit":"px"} -->
-				<div class="wp-block-cover" style="min-height:600px"><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( $hero_slide_three ); ?>" data-object-fit="cover" /><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span>
+			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:cover {"url":"<?php echo esc_url( $rt_carousel_slide_three ); ?>","dimRatio":30,"minHeight":600,"minHeightUnit":"px"} -->
+				<div class="wp-block-cover" style="min-height:600px"><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( $rt_carousel_slide_three ); ?>" data-object-fit="cover" /><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span>
 					<div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":1,"textColor":"white"} -->
 						<h1 class="wp-block-heading has-text-align-center has-white-color has-text-color">Join Our Community</h1>
 						<!-- /wp:heading -->

--- a/examples/patterns/logo-showcase.php
+++ b/examples/patterns/logo-showcase.php
@@ -11,12 +11,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$pattern_images_url = trailingslashit( RT_CAROUSEL_URL . '/examples/data/images' );
-$logo_one           = $pattern_images_url . 'logo-placeholder-1.svg';
-$logo_two           = $pattern_images_url . 'logo-placeholder-2.svg';
-$logo_three         = $pattern_images_url . 'logo-placeholder-3.svg';
-$logo_four          = $pattern_images_url . 'logo-placeholder-4.svg';
-$logo_five          = $pattern_images_url . 'logo-placeholder-5.svg';
+$rt_carousel_images_url = trailingslashit( RT_CAROUSEL_URL . '/examples/data/images' );
+$rt_carousel_logo_one   = $rt_carousel_images_url . 'logo-placeholder-1.svg';
+$rt_carousel_logo_two   = $rt_carousel_images_url . 'logo-placeholder-2.svg';
+$rt_carousel_logo_three = $rt_carousel_images_url . 'logo-placeholder-3.svg';
+$rt_carousel_logo_four  = $rt_carousel_images_url . 'logo-placeholder-4.svg';
+$rt_carousel_logo_five  = $rt_carousel_images_url . 'logo-placeholder-5.svg';
 ?>
 
 <!-- wp:rt-carousel/carousel {"loop":true,"autoplayDelay":3000,"autoplayStopOnInteraction":false,"ariaLabel":"Partner Logos","metadata":{"categories":["rt-carousel"],"patternName":"rt-carousel/logo-showcase","name":"rtCarousel: Logo Showcase"},"className":"wp-block-carousel-carousel is-style-columns-3"} -->
@@ -28,35 +28,35 @@ $logo_five          = $pattern_images_url . 'logo-placeholder-5.svg';
 	<div class="wp-block-rt-carousel-carousel-viewport embla wp-block-carousel-carousel-viewport">
 		<div class="embla__container"><!-- wp:rt-carousel/carousel-slide {"className":"wp-block-carousel-carousel-slide"} -->
 			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:image {"width":"200px","sizeSlug":"full","linkDestination":"none","align":"center","className":"is-style-rounded"} -->
-				<figure class="wp-block-image aligncenter size-full is-resized is-style-rounded"><img src="<?php echo esc_url( $logo_one ); ?>" alt="Partner Logo 1" style="width:200px" /></figure>
+				<figure class="wp-block-image aligncenter size-full is-resized is-style-rounded"><img src="<?php echo esc_url( $rt_carousel_logo_one ); ?>" alt="Partner Logo 1" style="width:200px" /></figure>
 				<!-- /wp:image -->
 			</div>
 			<!-- /wp:rt-carousel/carousel-slide -->
 
 			<!-- wp:rt-carousel/carousel-slide {"className":"wp-block-carousel-carousel-slide"} -->
 			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:image {"width":"200px","sizeSlug":"full","linkDestination":"none","align":"center","className":"is-style-rounded"} -->
-				<figure class="wp-block-image aligncenter size-full is-resized is-style-rounded"><img src="<?php echo esc_url( $logo_two ); ?>" alt="Partner Logo 2" style="width:200px" /></figure>
+				<figure class="wp-block-image aligncenter size-full is-resized is-style-rounded"><img src="<?php echo esc_url( $rt_carousel_logo_two ); ?>" alt="Partner Logo 2" style="width:200px" /></figure>
 				<!-- /wp:image -->
 			</div>
 			<!-- /wp:rt-carousel/carousel-slide -->
 
 			<!-- wp:rt-carousel/carousel-slide {"className":"wp-block-carousel-carousel-slide"} -->
 			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:image {"width":"200px","sizeSlug":"full","linkDestination":"none","align":"center","className":"is-style-rounded"} -->
-				<figure class="wp-block-image aligncenter size-full is-resized is-style-rounded"><img src="<?php echo esc_url( $logo_three ); ?>" alt="Partner Logo 3" style="width:200px" /></figure>
+				<figure class="wp-block-image aligncenter size-full is-resized is-style-rounded"><img src="<?php echo esc_url( $rt_carousel_logo_three ); ?>" alt="Partner Logo 3" style="width:200px" /></figure>
 				<!-- /wp:image -->
 			</div>
 			<!-- /wp:rt-carousel/carousel-slide -->
 
 			<!-- wp:rt-carousel/carousel-slide {"className":"wp-block-carousel-carousel-slide"} -->
 			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:image {"width":"200px","sizeSlug":"full","linkDestination":"none","align":"center","className":"is-style-rounded"} -->
-				<figure class="wp-block-image aligncenter size-full is-resized is-style-rounded"><img src="<?php echo esc_url( $logo_four ); ?>" alt="Partner Logo 4" style="width:200px" /></figure>
+				<figure class="wp-block-image aligncenter size-full is-resized is-style-rounded"><img src="<?php echo esc_url( $rt_carousel_logo_four ); ?>" alt="Partner Logo 4" style="width:200px" /></figure>
 				<!-- /wp:image -->
 			</div>
 			<!-- /wp:rt-carousel/carousel-slide -->
 
 			<!-- wp:rt-carousel/carousel-slide {"className":"wp-block-carousel-carousel-slide"} -->
 			<div class="wp-block-rt-carousel-carousel-slide embla__slide wp-block-carousel-carousel-slide" role="group" aria-roledescription="slide" data-wp-interactive="rt-carousel/carousel" data-wp-class--is-active="callbacks.isSlideActive" data-wp-bind--aria-current="callbacks.isSlideActive"><!-- wp:image {"width":"200px","sizeSlug":"full","linkDestination":"none","align":"center","className":"is-style-rounded"} -->
-				<figure class="wp-block-image aligncenter size-full is-resized is-style-rounded"><img src="<?php echo esc_url( $logo_five ); ?>" alt="Partner Logo 5" style="width:200px" /></figure>
+				<figure class="wp-block-image aligncenter size-full is-resized is-style-rounded"><img src="<?php echo esc_url( $rt_carousel_logo_five ); ?>" alt="Partner Logo 5" style="width:200px" /></figure>
 				<!-- /wp:image -->
 			</div>
 			<!-- /wp:rt-carousel/carousel-slide -->

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -40,26 +40,41 @@ class Plugin {
 		add_action( 'init', [ $this, 'register_pattern_category' ] );
 		add_action( 'init', [ $this, 'register_block_patterns' ] );
 		add_action( 'admin_notices', [ $this, 'legacy_plugin_notice' ] );
+		add_action( 'network_admin_notices', [ $this, 'legacy_plugin_notice' ] );
 	}
 
 	/**
 	 * Show an admin notice if the legacy "Carousel Kit" plugin is still active.
+	 *
+	 * Handles both single-site and network-wide activations.
 	 */
 	public function legacy_plugin_notice(): void {
-		$old_plugin = 'carousel-kit/carousel-kit.php';
+		$old_plugin   = 'carousel-kit/carousel-kit.php';
+		$network_wide = is_multisite() && is_plugin_active_for_network( $old_plugin );
 
 		if ( ! is_plugin_active( $old_plugin ) ) {
 			return;
 		}
 
-		if ( ! current_user_can( 'activate_plugins' ) ) {
+		if ( $network_wide && ! current_user_can( 'manage_network_plugins' ) ) {
 			return;
 		}
 
-		$deactivate_url = wp_nonce_url(
-			admin_url( 'plugins.php?action=deactivate&plugin=' . urlencode( $old_plugin ) ),
-			'deactivate-plugin_' . $old_plugin
-		);
+		if ( ! $network_wide && ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		if ( $network_wide ) {
+			$deactivate_url = wp_nonce_url(
+				network_admin_url( 'plugins.php?action=deactivate&plugin=' . urlencode( $old_plugin ) . '&networkwide=1' ),
+				'deactivate-plugin_' . $old_plugin
+			);
+		} else {
+			$deactivate_url = wp_nonce_url(
+				admin_url( 'plugins.php?action=deactivate&plugin=' . urlencode( $old_plugin ) ),
+				'deactivate-plugin_' . $old_plugin
+			);
+		}
 
 		printf(
 			'<div class="notice notice-warning is-dismissible"><p>%s <a href="%s">%s</a></p></div>',

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -64,6 +64,11 @@ class Plugin {
 			return;
 		}
 
+		// Only show the notice in the matching admin context.
+		if ( $network_wide !== is_network_admin() ) {
+			return;
+		}
+
 		if ( $network_wide ) {
 			$deactivate_url = wp_nonce_url(
 				network_admin_url( 'plugins.php?action=deactivate&plugin=' . urlencode( $old_plugin ) . '&networkwide=1' ),

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -71,12 +71,25 @@ class Plugin {
 
 		if ( $network_wide ) {
 			$deactivate_url = wp_nonce_url(
-				network_admin_url( 'plugins.php?action=deactivate&plugin=' . rawurlencode( $old_plugin ) . '&networkwide=1' ),
+				add_query_arg(
+					[
+						'action'      => 'deactivate',
+						'plugin'      => $old_plugin,
+						'networkwide' => '1',
+					],
+					network_admin_url( 'plugins.php' )
+				),
 				'deactivate-plugin_' . $old_plugin
 			);
 		} else {
 			$deactivate_url = wp_nonce_url(
-				admin_url( 'plugins.php?action=deactivate&plugin=' . rawurlencode( $old_plugin ) ),
+				add_query_arg(
+					[
+						'action' => 'deactivate',
+						'plugin' => $old_plugin,
+					],
+					admin_url( 'plugins.php' )
+				),
 				'deactivate-plugin_' . $old_plugin
 			);
 		}

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -65,18 +65,18 @@ class Plugin {
 		}
 
 		// Only show the notice in the matching admin context.
-		if ( $network_wide !== is_network_admin() ) {
+		if ( is_network_admin() !== $network_wide ) {
 			return;
 		}
 
 		if ( $network_wide ) {
 			$deactivate_url = wp_nonce_url(
-				network_admin_url( 'plugins.php?action=deactivate&plugin=' . urlencode( $old_plugin ) . '&networkwide=1' ),
+				network_admin_url( 'plugins.php?action=deactivate&plugin=' . rawurlencode( $old_plugin ) . '&networkwide=1' ),
 				'deactivate-plugin_' . $old_plugin
 			);
 		} else {
 			$deactivate_url = wp_nonce_url(
-				admin_url( 'plugins.php?action=deactivate&plugin=' . urlencode( $old_plugin ) ),
+				admin_url( 'plugins.php?action=deactivate&plugin=' . rawurlencode( $old_plugin ) ),
 				'deactivate-plugin_' . $old_plugin
 			);
 		}

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -39,45 +39,33 @@ class Plugin {
 		add_filter( 'block_categories_all', [ $this, 'register_block_category' ] );
 		add_action( 'init', [ $this, 'register_pattern_category' ] );
 		add_action( 'init', [ $this, 'register_block_patterns' ] );
-		add_action( 'admin_init', [ $this, 'deactivate_legacy_plugin' ] );
+		add_action( 'admin_notices', [ $this, 'legacy_plugin_notice' ] );
 	}
 
 	/**
-	 * Deactivate the legacy "Carousel Kit" plugin if still active.
-	 *
-	 * Handles both single-site and network-wide activations.
+	 * Show an admin notice if the legacy "Carousel Kit" plugin is still active.
 	 */
-	public function deactivate_legacy_plugin(): void {
+	public function legacy_plugin_notice(): void {
 		$old_plugin = 'carousel-kit/carousel-kit.php';
 
 		if ( ! is_plugin_active( $old_plugin ) ) {
 			return;
 		}
 
-		$network_wide = is_multisite() && is_plugin_active_for_network( $old_plugin );
-		if ( $network_wide && ! current_user_can( 'manage_network_plugins' ) ) {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
 			return;
 		}
 
-		if ( ! $network_wide && ! current_user_can( 'activate_plugins' ) ) {
-			return;
-		}
+		$deactivate_url = wp_nonce_url(
+			admin_url( 'plugins.php?action=deactivate&plugin=' . urlencode( $old_plugin ) ),
+			'deactivate-plugin_' . $old_plugin
+		);
 
-		// Silent flag prevents deactivation hooks from firing redirect.
-		deactivate_plugins( $old_plugin, true, $network_wide );
-
-		if ( is_plugin_active( $old_plugin ) ) {
-			return;
-		}
-
-		add_action(
-			'admin_notices',
-			static function (): void {
-				printf(
-					'<div class="notice notice-info is-dismissible"><p>%s</p></div>',
-					esc_html__( 'The old "Carousel Kit" plugin has been deactivated. rtCarousel is its replacement.', 'rt-carousel' )
-				);
-			}
+		printf(
+			'<div class="notice notice-warning is-dismissible"><p>%s <a href="%s">%s</a></p></div>',
+			esc_html__( 'The "Carousel Kit" plugin is still active. rtCarousel is its replacement — please deactivate Carousel Kit.', 'rt-carousel' ),
+			esc_url( $deactivate_url ),
+			esc_html__( 'Deactivate Carousel Kit', 'rt-carousel' )
 		);
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -129,4 +129,4 @@ rtCarousel is the successor to Carousel Kit. Simply install and activate rtCarou
 == Upgrade Notice ==
 
 = 2.0.0 =
-Plugin renamed from "Carousel Kit" to "rtCarousel". Existing carousel blocks are automatically migrated on activation. The old Carousel Kit plugin is deactivated automatically and can be safely deleted.
+Plugin renamed from "Carousel Kit" to "rtCarousel". Existing carousel blocks are automatically migrated on activation. You will see an admin notice prompting you to deactivate the old Carousel Kit plugin, which can then be safely deleted.

--- a/readme.txt
+++ b/readme.txt
@@ -77,7 +77,7 @@ Yes. Each carousel instance maintains its own independent state.
 
 = I am using "Carousel Kit". How do I upgrade to rtCarousel? =
 
-rtCarousel is the successor to Carousel Kit. Simply install and activate rtCarousel — it will automatically migrate all existing carousel blocks in your content and deactivate the old plugin. No manual steps are needed. You can safely delete the old Carousel Kit plugin afterward.
+rtCarousel is the successor to Carousel Kit. Simply install and activate rtCarousel — it will automatically migrate all existing carousel blocks in your content. You will see an admin notice prompting you to deactivate the old Carousel Kit plugin. After deactivating it, you can safely delete it.
 
 == Screenshots ==
 

--- a/tests/php/Unit/PluginTest.php
+++ b/tests/php/Unit/PluginTest.php
@@ -456,6 +456,7 @@ class PluginTest extends UnitTestCase {
 		Functions\expect( 'is_multisite' )->andReturn( false );
 		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
 		Functions\expect( 'current_user_can' )->once()->with( 'activate_plugins' )->andReturn( true );
+		Functions\expect( 'is_network_admin' )->andReturn( false );
 		Functions\expect( 'admin_url' )->once()->andReturnUsing(
 			function ( string $path ): string {
 				return 'https://example.com/wp-admin/' . $path;
@@ -507,6 +508,7 @@ class PluginTest extends UnitTestCase {
 		Functions\expect( 'is_plugin_active_for_network' )->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
 		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
 		Functions\expect( 'current_user_can' )->once()->with( 'manage_network_plugins' )->andReturn( true );
+		Functions\expect( 'is_network_admin' )->andReturn( true );
 		Functions\expect( 'network_admin_url' )->once()->andReturnUsing(
 			function ( string $path ): string {
 				return 'https://example.com/wp-admin/network/' . $path;
@@ -525,5 +527,47 @@ class PluginTest extends UnitTestCase {
 		$this->assertStringContainsString( 'notice-warning', $output );
 		$this->assertStringContainsString( 'networkwide=1', $output );
 		$this->assertStringContainsString( 'network/', $output );
+	}
+
+	/**
+	 * Test that legacy_plugin_notice outputs nothing for network-activated plugin on site admin.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_plugin_notice_no_output_network_plugin_on_site_admin(): void {
+		Functions\expect( 'is_multisite' )->andReturn( true );
+		Functions\expect( 'is_plugin_active_for_network' )->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
+		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
+		Functions\expect( 'current_user_can' )->once()->with( 'manage_network_plugins' )->andReturn( true );
+		Functions\expect( 'is_network_admin' )->andReturn( false );
+
+		$instance = $this->getPluginInstance();
+
+		ob_start();
+		$this->invokeMethod( $instance, 'legacy_plugin_notice' );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that legacy_plugin_notice outputs nothing for site-activated plugin on network admin.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_plugin_notice_no_output_site_plugin_on_network_admin(): void {
+		Functions\expect( 'is_multisite' )->andReturn( true );
+		Functions\expect( 'is_plugin_active_for_network' )->with( 'carousel-kit/carousel-kit.php' )->andReturn( false );
+		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
+		Functions\expect( 'current_user_can' )->once()->with( 'activate_plugins' )->andReturn( true );
+		Functions\expect( 'is_network_admin' )->andReturn( true );
+
+		$instance = $this->getPluginInstance();
+
+		ob_start();
+		$this->invokeMethod( $instance, 'legacy_plugin_notice' );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
 	}
 }

--- a/tests/php/Unit/PluginTest.php
+++ b/tests/php/Unit/PluginTest.php
@@ -35,6 +35,7 @@ class PluginTest extends UnitTestCase {
 		'carousel',
 		'carousel/controls',
 		'carousel/dots',
+		'carousel/progress',
 		'carousel/viewport',
 		'carousel/slide',
 	];
@@ -149,7 +150,7 @@ class PluginTest extends UnitTestCase {
 		$instance = $this->getPluginInstance();
 		$this->invokeMethod( $instance, 'register_blocks' );
 
-		$this->assertCount( 5, $registered_blocks );
+		$this->assertCount( 6, $registered_blocks );
 
 		// Verify each expected block is registered
 		foreach ( self::EXPECTED_BLOCKS as $block ) {
@@ -184,8 +185,9 @@ class PluginTest extends UnitTestCase {
 		$this->assertStringContainsString( '/blocks/carousel', $registered_blocks[0] );
 		$this->assertStringContainsString( '/blocks/carousel/controls', $registered_blocks[1] );
 		$this->assertStringContainsString( '/blocks/carousel/dots', $registered_blocks[2] );
-		$this->assertStringContainsString( '/blocks/carousel/viewport', $registered_blocks[3] );
-		$this->assertStringContainsString( '/blocks/carousel/slide', $registered_blocks[4] );
+		$this->assertStringContainsString( '/blocks/carousel/progress', $registered_blocks[3] );
+		$this->assertStringContainsString( '/blocks/carousel/viewport', $registered_blocks[4] );
+		$this->assertStringContainsString( '/blocks/carousel/slide', $registered_blocks[5] );
 	}
 
 	/**
@@ -196,7 +198,7 @@ class PluginTest extends UnitTestCase {
 	public function test_register_blocks_handles_missing_build_path(): void {
 		// The actual behavior check: register_block_type should be called
 		// for each block when the constant is defined (as it is in our tests).
-		Functions\expect( 'register_block_type' )->times( 5 );
+		Functions\expect( 'register_block_type' )->times( 6 );
 
 		$instance = $this->getPluginInstance();
 		$this->invokeMethod( $instance, 'register_blocks' );
@@ -406,5 +408,122 @@ class PluginTest extends UnitTestCase {
 
 		// Assert completed successfully
 		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test that legacy_plugin_notice outputs nothing when old plugin is inactive.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_plugin_notice_no_output_when_inactive(): void {
+		Functions\expect( 'is_multisite' )->andReturn( false );
+		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( false );
+
+		$instance = $this->getPluginInstance();
+
+		ob_start();
+		$this->invokeMethod( $instance, 'legacy_plugin_notice' );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that legacy_plugin_notice outputs nothing when user lacks capability (single-site).
+	 *
+	 * @return void
+	 */
+	public function test_legacy_plugin_notice_no_output_without_capability(): void {
+		Functions\expect( 'is_multisite' )->andReturn( false );
+		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
+		Functions\expect( 'current_user_can' )->once()->with( 'activate_plugins' )->andReturn( false );
+
+		$instance = $this->getPluginInstance();
+
+		ob_start();
+		$this->invokeMethod( $instance, 'legacy_plugin_notice' );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that legacy_plugin_notice renders notice with deactivation link (single-site).
+	 *
+	 * @return void
+	 */
+	public function test_legacy_plugin_notice_renders_on_single_site(): void {
+		Functions\expect( 'is_multisite' )->andReturn( false );
+		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
+		Functions\expect( 'current_user_can' )->once()->with( 'activate_plugins' )->andReturn( true );
+		Functions\expect( 'admin_url' )->once()->andReturnUsing(
+			function ( string $path ): string {
+				return 'https://example.com/wp-admin/' . $path;
+			}
+		);
+		Functions\expect( 'wp_nonce_url' )->once()->andReturnFirstArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'esc_url' )->returnArg();
+
+		$instance = $this->getPluginInstance();
+
+		ob_start();
+		$this->invokeMethod( $instance, 'legacy_plugin_notice' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringContainsString( 'Carousel Kit', $output );
+		$this->assertStringContainsString( 'action=deactivate', $output );
+		$this->assertStringNotContainsString( 'networkwide=1', $output );
+	}
+
+	/**
+	 * Test that legacy_plugin_notice outputs nothing on multisite without manage_network_plugins.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_plugin_notice_no_output_without_network_capability(): void {
+		Functions\expect( 'is_multisite' )->andReturn( true );
+		Functions\expect( 'is_plugin_active_for_network' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
+		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
+		Functions\expect( 'current_user_can' )->once()->with( 'manage_network_plugins' )->andReturn( false );
+
+		$instance = $this->getPluginInstance();
+
+		ob_start();
+		$this->invokeMethod( $instance, 'legacy_plugin_notice' );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that legacy_plugin_notice renders with network deactivation URL on multisite.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_plugin_notice_renders_network_url_on_multisite(): void {
+		Functions\expect( 'is_multisite' )->andReturn( true );
+		Functions\expect( 'is_plugin_active_for_network' )->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
+		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
+		Functions\expect( 'current_user_can' )->once()->with( 'manage_network_plugins' )->andReturn( true );
+		Functions\expect( 'network_admin_url' )->once()->andReturnUsing(
+			function ( string $path ): string {
+				return 'https://example.com/wp-admin/network/' . $path;
+			}
+		);
+		Functions\expect( 'wp_nonce_url' )->once()->andReturnFirstArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'esc_url' )->returnArg();
+
+		$instance = $this->getPluginInstance();
+
+		ob_start();
+		$this->invokeMethod( $instance, 'legacy_plugin_notice' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringContainsString( 'networkwide=1', $output );
+		$this->assertStringContainsString( 'network/', $output );
 	}
 }

--- a/tests/php/Unit/PluginTest.php
+++ b/tests/php/Unit/PluginTest.php
@@ -166,35 +166,6 @@ class PluginTest extends UnitTestCase {
 	}
 
 	/**
-	 * Test that all expected blocks are registered regardless of order.
-	 *
-	 * @return void
-	 */
-	public function test_register_blocks_contains_all_expected(): void {
-		$registered_blocks = [];
-
-		Functions\when( 'register_block_type' )->alias(
-			function ( string $path ) use ( &$registered_blocks ): void {
-				$registered_blocks[] = $path;
-			}
-		);
-
-		$instance = $this->getPluginInstance();
-		$this->invokeMethod( $instance, 'register_blocks' );
-
-		foreach ( self::EXPECTED_BLOCKS as $block ) {
-			$found = false;
-			foreach ( $registered_blocks as $path ) {
-				if ( str_contains( $path, "/blocks/{$block}" ) ) {
-					$found = true;
-					break;
-				}
-			}
-			$this->assertTrue( $found, "Block '{$block}' should be registered." );
-		}
-	}
-
-	/**
 	 * Test that register_blocks does nothing when build path is not defined.
 	 *
 	 * @return void

--- a/tests/php/Unit/PluginTest.php
+++ b/tests/php/Unit/PluginTest.php
@@ -166,11 +166,11 @@ class PluginTest extends UnitTestCase {
 	}
 
 	/**
-	 * Test that blocks are registered in the correct order.
+	 * Test that all expected blocks are registered regardless of order.
 	 *
 	 * @return void
 	 */
-	public function test_register_blocks_in_correct_order(): void {
+	public function test_register_blocks_contains_all_expected(): void {
 		$registered_blocks = [];
 
 		Functions\when( 'register_block_type' )->alias(
@@ -182,12 +182,16 @@ class PluginTest extends UnitTestCase {
 		$instance = $this->getPluginInstance();
 		$this->invokeMethod( $instance, 'register_blocks' );
 
-		$this->assertStringContainsString( '/blocks/carousel', $registered_blocks[0] );
-		$this->assertStringContainsString( '/blocks/carousel/controls', $registered_blocks[1] );
-		$this->assertStringContainsString( '/blocks/carousel/dots', $registered_blocks[2] );
-		$this->assertStringContainsString( '/blocks/carousel/progress', $registered_blocks[3] );
-		$this->assertStringContainsString( '/blocks/carousel/viewport', $registered_blocks[4] );
-		$this->assertStringContainsString( '/blocks/carousel/slide', $registered_blocks[5] );
+		foreach ( self::EXPECTED_BLOCKS as $block ) {
+			$found = false;
+			foreach ( $registered_blocks as $path ) {
+				if ( str_contains( $path, "/blocks/{$block}" ) ) {
+					$found = true;
+					break;
+				}
+			}
+			$this->assertTrue( $found, "Block '{$block}' should be registered." );
+		}
 	}
 
 	/**
@@ -457,9 +461,10 @@ class PluginTest extends UnitTestCase {
 		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
 		Functions\expect( 'current_user_can' )->once()->with( 'activate_plugins' )->andReturn( true );
 		Functions\expect( 'is_network_admin' )->andReturn( false );
-		Functions\expect( 'admin_url' )->once()->andReturnUsing(
-			function ( string $path ): string {
-				return 'https://example.com/wp-admin/' . $path;
+		Functions\expect( 'admin_url' )->once()->with( 'plugins.php' )->andReturn( 'https://example.com/wp-admin/plugins.php' );
+		Functions\expect( 'add_query_arg' )->once()->andReturnUsing(
+			function ( array $args, string $url ): string {
+				return $url . '?' . http_build_query( $args );
 			}
 		);
 		Functions\expect( 'wp_nonce_url' )->once()->andReturnFirstArg();
@@ -509,9 +514,10 @@ class PluginTest extends UnitTestCase {
 		Functions\expect( 'is_plugin_active' )->once()->with( 'carousel-kit/carousel-kit.php' )->andReturn( true );
 		Functions\expect( 'current_user_can' )->once()->with( 'manage_network_plugins' )->andReturn( true );
 		Functions\expect( 'is_network_admin' )->andReturn( true );
-		Functions\expect( 'network_admin_url' )->once()->andReturnUsing(
-			function ( string $path ): string {
-				return 'https://example.com/wp-admin/network/' . $path;
+		Functions\expect( 'network_admin_url' )->once()->with( 'plugins.php' )->andReturn( 'https://example.com/wp-admin/network/plugins.php' );
+		Functions\expect( 'add_query_arg' )->once()->andReturnUsing(
+			function ( array $args, string $url ): string {
+				return $url . '?' . http_build_query( $args );
 			}
 		);
 		Functions\expect( 'wp_nonce_url' )->once()->andReturnFirstArg();


### PR DESCRIPTION
## Summary

Addresses WP.org plugin review feedback — plugins must not change the activation status of other plugins programmatically.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

<!-- 'Closes' will automatically close the linked issue when this PR is merged. -->
<!-- 'Relates to' is for issues that are relevant but won't be closed by this PR. -->
Closes #<issue-number>
Relates to #<issue-number> (if applicable)

## What changed

- **Removed** `deactivate_plugins()` call that automatically deactivated the legacy "Carousel Kit" plugin
- **Added** `legacy_plugin_notice()` — displays a dismissible admin warning with a one-click deactivation link when Carousel Kit is still active
- **Updated** FAQ in readme.txt to reflect the new manual deactivation flow

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

<img width="1331" height="88" alt="image" src="https://github.com/user-attachments/assets/3f5eace0-4b88-4b04-8034-a8ed9aaeead9" />


## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [x] I have updated docs where needed
- [ ] I have checked for breaking changes
