### PR TITLE
[Release]: Prepare release for 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2.0.1](https://github.com/rtCamp/rt-carousel/compare/v2.0.0...v2.0.1) (2026-05-04)
+
+
+### Features
+
+* add a11y announcements for carousel slide changes ([#125](https://github.com/rtCamp/rt-carousel/issues/125)) ([b7a2240](https://github.com/rtCamp/rt-carousel/commit/b7a2240))
+
+
+### Bug Fixes
+
+* carousel dot focus loss with VoiceOver activation ([#127](https://github.com/rtCamp/rt-carousel/issues/127)) ([366031e](https://github.com/rtCamp/rt-carousel/commit/366031e))
+
+
+### Refactors
+
+* replace automatic plugin deactivation with admin notice ([#129](https://github.com/rtCamp/rt-carousel/issues/129)) ([279a464](https://github.com/rtCamp/rt-carousel/commit/279a464))
+
+
 ## [2.0.0](https://github.com/rtCamp/rt-carousel/compare/v1.0.4...v2.0.0) (2026-04-13)
 
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,6 +30,18 @@ Thank you for your interest in contributing! We welcome all contributions, from 
 - **JavaScript/TypeScript**: We use the standard WordPress ESLint config. Run `npm run lint:js` to check.
 - **CSS/SCSS**: We use Stylelint. Run `npm run lint:css` to check.
 
+## Block `save()` Changes
+
+If your changes modify a block's `save()` output — including `data-wp-context`, HTML structure, class names, or new elements — you **must** add a deprecation entry in the block's `deprecated.tsx`.
+
+1. Copy the previous `save()` function into the `deprecated` array.
+2. Include the `attributes` and `supports` from the old version.
+3. Use `innerBlocks: true` if the block has inner blocks.
+
+Without this, existing content will show "Block contains unexpected or invalid content" errors in the editor.
+
+See the [Block Deprecation API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/) for details.
+
 ## Building the Plugin
 
 To create a production-ready ZIP file:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,8 +35,8 @@ Thank you for your interest in contributing! We welcome all contributions, from 
 If your changes modify a block's `save()` output — including `data-wp-context`, HTML structure, class names, or new elements — you **must** add a deprecation entry in the block's `deprecated.tsx`.
 
 1. Copy the previous `save()` function into the `deprecated` array.
-2. Include the `attributes` and `supports` from the old version.
-3. Use `innerBlocks: true` if the block has inner blocks.
+2. Include the `attributes` and `supports` from the old version (copy the full `supports` from `block.json` — don't simplify it, or alignment/color classes will fail validation).
+3. For blocks with inner blocks, use `useInnerBlocksProps.save()` in the deprecated `save()` function, just like the current save does.
 
 Without this, existing content will show "Block contains unexpected or invalid content" errors in the editor.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rt-carousel",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rt-carousel",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@wordpress/babel-preset-default": "8.38.0",
         "@wordpress/block-editor": "^15.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rt-carousel",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Carousel block using Embla and WordPress Interactivity API",
   "author": "rtCamp",
   "private": true,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: carousel, slider, block, interactivity-api, embla
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -84,6 +84,12 @@ rtCarousel is the successor to Carousel Kit. Simply install and activate rtCarou
 1. Carousel block in the editor with multiple slides
 
 == Changelog ==
+
+= 2.0.1 =
+New: Add a11y announcements for carousel slide changes
+Fix: Carousel dot focus loss with VoiceOver activation
+Refactor: Automatic plugin deactivation with admin notice
+
 
 = 2.0.0 =
 * New: Carousel progress bar block

--- a/readme.txt
+++ b/readme.txt
@@ -86,9 +86,9 @@ rtCarousel is the successor to Carousel Kit. Simply install and activate rtCarou
 == Changelog ==
 
 = 2.0.1 =
-New: Add a11y announcements for carousel slide changes
-Fix: Carousel dot focus loss with VoiceOver activation
-Refactor: Automatic plugin deactivation with admin notice
+* New: Add a11y announcements for carousel slide changes
+* Fix: Carousel dot focus loss with VoiceOver activation
+* Refactor: Replace automatic plugin deactivation with an admin notice
 
 
 = 2.0.0 =

--- a/rt-carousel.php
+++ b/rt-carousel.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * License:     GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Version:     2.0.0
+ * Version:     2.0.1
  * Text Domain: rt-carousel
  *
  * @package rt-carousel

--- a/src/blocks/carousel/deprecated.tsx
+++ b/src/blocks/carousel/deprecated.tsx
@@ -1,0 +1,115 @@
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import type { CarouselAttributes } from './types';
+
+/**
+ * v2.0.0 save — before a11y announcement fields were added to context
+ * and the live-region <span> was appended.
+ *
+ * @param {Object}             root0            Component props.
+ * @param {CarouselAttributes} root0.attributes Block attributes.
+ */
+function SaveV200( {
+	attributes,
+}: {
+	attributes: CarouselAttributes;
+} ) {
+	const {
+		loop,
+		dragFree,
+		carouselAlign,
+		containScroll,
+		direction,
+		autoplay,
+		autoplayDelay,
+		autoplayStopOnInteraction,
+		autoplayStopOnMouseEnter,
+		ariaLabel,
+		slideGap,
+		axis,
+		height,
+		slidesToScroll,
+	} = attributes;
+
+	const context = {
+		options: {
+			loop,
+			dragFree,
+			align: carouselAlign,
+			containScroll,
+			direction,
+			axis,
+			slidesToScroll: slidesToScroll === 'auto' ? 'auto' : parseInt( slidesToScroll, 10 ),
+		},
+		autoplay: autoplay
+			? {
+				delay: autoplayDelay,
+				stopOnInteraction: autoplayStopOnInteraction,
+				stopOnMouseEnter: autoplayStopOnMouseEnter,
+			}
+			: false,
+		isPlaying: !! autoplay,
+		timerIterationId: 0,
+		selectedIndex: -1,
+		scrollSnaps: [] as { index: number }[],
+		canScrollPrev: false,
+		canScrollNext: false,
+		scrollProgress: 0,
+		slideCount: 0,
+		/* translators: %d: slide number */
+		ariaLabelPattern: __( 'Go to slide %d', 'rt-carousel' ),
+	};
+
+	const blockProps = useBlockProps.save( {
+		className: 'rt-carousel',
+		role: 'region',
+		'aria-roledescription': 'carousel',
+		'aria-label': ariaLabel,
+		dir: direction,
+		'data-axis': axis,
+		'data-loop': loop ? 'true' : undefined,
+		'data-wp-interactive': 'rt-carousel/carousel',
+		'data-wp-context': JSON.stringify( context ),
+		'data-wp-init': 'callbacks.initCarousel',
+		style: {
+			'--rt-carousel-gap': `${ slideGap }px`,
+			'--rt-carousel-height': axis === 'y' ? height : undefined,
+		} as React.CSSProperties,
+	} );
+
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps ) as ReturnType<
+		typeof useInnerBlocksProps.save
+	> & {
+		children: React.ReactNode;
+	};
+
+	return <div { ...innerBlocksProps } />;
+}
+
+const deprecated = [
+	{
+		attributes: {
+			allowedSlideBlocks: { type: 'array' as const, default: [] },
+			loop: { type: 'boolean' as const, default: false },
+			dragFree: { type: 'boolean' as const, default: false },
+			carouselAlign: { type: 'string' as const, default: 'start' },
+			containScroll: { type: 'string' as const, default: 'trimSnaps' },
+			direction: { type: 'string' as const, default: 'ltr' },
+			axis: { type: 'string' as const, default: 'x' },
+			height: { type: 'string' as const, default: '300px' },
+			autoplay: { type: 'boolean' as const, default: false },
+			autoplayDelay: { type: 'number' as const, default: 4000 },
+			autoplayStopOnInteraction: { type: 'boolean' as const, default: true },
+			autoplayStopOnMouseEnter: { type: 'boolean' as const, default: false },
+			ariaLabel: { type: 'string' as const, default: 'Carousel' },
+			slideGap: { type: 'number' as const, default: 0 },
+			slidesToScroll: { type: 'string' as const, default: '1' },
+		},
+		supports: {
+			className: true,
+		},
+		save: SaveV200,
+	},
+];
+
+export default deprecated;

--- a/src/blocks/carousel/deprecated.tsx
+++ b/src/blocks/carousel/deprecated.tsx
@@ -106,7 +106,13 @@ const deprecated = [
 			slidesToScroll: { type: 'string' as const, default: '1' },
 		},
 		supports: {
-			className: true,
+			interactivity: true,
+			align: [ 'wide', 'full' ],
+			html: false,
+			color: {
+				text: false,
+				background: true,
+			},
 		},
 		save: SaveV200,
 	},

--- a/src/blocks/carousel/index.ts
+++ b/src/blocks/carousel/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@wordpress/blocks';
 import Edit from './edit';
 import Save from './save';
+import deprecated from './deprecated';
 import './style.scss';
 import './editor.scss';
 import metadata from './block.json';
@@ -14,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 registerBlockType( metadata as BlockConfiguration<CarouselAttributes>, {
 	edit: Edit,
 	save: Save,
+	deprecated,
 } );
 
 const styles = [


### PR DESCRIPTION
## Summary

This PR will make the plugin ready for releaseing `v2.0.1`

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

<!-- 'Closes' will automatically close the linked issue when this PR is merged. -->
<!-- 'Relates to' is for issues that are relevant but won't be closed by this PR. -->
Closes #<issue-number>
Relates to # https://github.com/rtCamp/marketing/issues/1257

## What changed

- Change log updated
- Readme updated
- Plugin version updated

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [ ] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [ ] I have checked for breaking changes
