### PR TITLE
feat: add Embla initialization hooks

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ addFilter(
 );
 ```
 
-Both filters receive the carousel context object as the third argument. `rtcamp.carouselKit.emblaPlugins` also receives the filtered options on `options`.
+Both filter callbacks receive the filtered value as their first argument and the filter context object as their second argument. `rtcamp.carouselKit.emblaPlugins` also receives the filtered options on the `options` property of this object.
 
 rtCarousel also exposes an action after Embla has initialized so integrations can call Embla methods or subscribe to Embla events:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,6 +5,54 @@ This block uses the **WordPress Interactivity API** to manage state and logic. Y
 ## Store Namespace
 `rt-carousel/carousel`
 
+## Embla Initialization Filters
+
+rtCarousel exposes JavaScript filters immediately before calling `EmblaCarousel( viewport, options, plugins )`, allowing runtime customization without changing saved block markup.
+
+```js
+import { addFilter } from '@wordpress/hooks';
+import AutoHeight from 'embla-carousel-auto-height';
+
+addFilter(
+    'rtcamp.carouselKit.emblaOptions',
+    'my-plugin/custom-options',
+    ( options ) => ( { ...options, duration: 40 } )
+);
+
+addFilter(
+    'rtcamp.carouselKit.emblaPlugins',
+    'my-plugin/auto-height',
+    ( plugins ) => [ ...plugins, AutoHeight() ]
+);
+```
+
+Both filters receive the carousel context object as the third argument. `rtcamp.carouselKit.emblaPlugins` also receives the filtered options on `options`.
+
+rtCarousel also exposes an action after Embla has initialized so integrations can call Embla methods or subscribe to Embla events:
+
+```js
+import { addAction } from '@wordpress/hooks';
+
+addAction(
+    'rtcamp.carouselKit.emblaInit',
+    'my-plugin/custom-events',
+    ( embla, { root } ) => {
+        embla.on( 'select', () => {
+            root.dataset.selectedSlide = embla.selectedScrollSnap().toString();
+        } );
+    }
+);
+```
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `context` | `CarouselContext` | Interactivity API context for the carousel. |
+| `root` | `HTMLElement` | Root `.rt-carousel` element. |
+| `viewport` | `HTMLElement` | Embla viewport element. |
+| `dynamicListContainer` | `HTMLElement \| null` | Query Loop or Terms Query template container when present. |
+| `options` | `EmblaOptionsType` | Passed to `rtcamp.carouselKit.emblaPlugins` and `rtcamp.carouselKit.emblaInit`; contains filtered options. |
+| `plugins` | `EmblaPluginType[]` | Only passed to `rtcamp.carouselKit.emblaInit`; contains filtered plugins. |
+
 ## Context (`CarouselContext`)
 
 The following properties are exposed in the Interactivity API context:

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,19 +14,19 @@ import { addFilter } from '@wordpress/hooks';
 import AutoHeight from 'embla-carousel-auto-height';
 
 addFilter(
-    'rtcamp.carouselKit.emblaOptions',
+    'rtcamp.rtCarousel.emblaOptions',
     'my-plugin/custom-options',
     ( options ) => ( { ...options, duration: 40 } )
 );
 
 addFilter(
-    'rtcamp.carouselKit.emblaPlugins',
+    'rtcamp.rtCarousel.emblaPlugins',
     'my-plugin/auto-height',
     ( plugins ) => [ ...plugins, AutoHeight() ]
 );
 ```
 
-Both filter callbacks receive the filtered value as their first argument and the filter context object as their second argument. `rtcamp.carouselKit.emblaPlugins` also receives the filtered options on the `options` property of this object.
+Both filter callbacks receive the filtered value as their first argument and the filter context object as their second argument. `rtcamp.rtCarousel.emblaPlugins` also receives the filtered options on the `options` property of this object.
 
 rtCarousel also exposes an action after Embla has initialized so integrations can call Embla methods or subscribe to Embla events:
 
@@ -34,7 +34,7 @@ rtCarousel also exposes an action after Embla has initialized so integrations ca
 import { addAction } from '@wordpress/hooks';
 
 addAction(
-    'rtcamp.carouselKit.emblaInit',
+    'rtcamp.rtCarousel.emblaInit',
     'my-plugin/custom-events',
     ( embla, { root } ) => {
         embla.on( 'select', () => {
@@ -50,8 +50,8 @@ addAction(
 | `root` | `HTMLElement` | Root `.rt-carousel` element. |
 | `viewport` | `HTMLElement` | Embla viewport element. |
 | `dynamicListContainer` | `HTMLElement \| null` | Query Loop or Terms Query template container when present. |
-| `options` | `EmblaOptionsType` | Passed to `rtcamp.carouselKit.emblaPlugins` and `rtcamp.carouselKit.emblaInit`; contains filtered options. |
-| `plugins` | `EmblaPluginType[]` | Only passed to `rtcamp.carouselKit.emblaInit`; contains filtered plugins. |
+| `options` | `EmblaOptionsType` | Passed to `rtcamp.rtCarousel.emblaPlugins` and `rtcamp.rtCarousel.emblaInit`; contains filtered options. |
+| `plugins` | `EmblaPluginType[]` | Only passed to `rtcamp.rtCarousel.emblaInit`; contains filtered plugins. |
 
 ## Context (`CarouselContext`)
 

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -914,6 +914,92 @@ describe( 'Carousel View Module', () => {
 					delete ( window as HooksWindow ).wp;
 				}
 			} );
+
+			it( 'should keep original Embla options when the options filter returns undefined', () => {
+				const mockContext = createMockContext( {
+					options: { duration: 25 },
+				} );
+				const { wrapper, viewport } = createMockCarouselDOM();
+				const mockEmbla = createMockEmblaInstance();
+				const originalIntersectionObserver = window.IntersectionObserver;
+				const applyFilters = jest.fn( ( hookName, value ) => {
+					if ( hookName === 'rtcamp.carouselKit.emblaOptions' ) {
+						return undefined;
+					}
+					return value;
+				} );
+
+				mockVisibleViewport( viewport );
+
+				( window as HooksWindow ).wp = {
+					hooks: {
+						applyFilters,
+					},
+				};
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: wrapper } );
+				( EmblaCarousel as unknown as jest.Mock ).mockReturnValue( mockEmbla );
+				delete ( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver;
+
+				try {
+					storeConfig.callbacks.initCarousel();
+
+					expect( EmblaCarousel ).toHaveBeenCalledWith(
+						viewport,
+						expect.objectContaining( { duration: 25 } ),
+						[],
+					);
+				} finally {
+					( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver =
+						originalIntersectionObserver;
+					delete ( window as HooksWindow ).wp;
+				}
+			} );
+
+			it( 'should keep original Embla plugins when the plugins filter returns a non-array value', () => {
+				const mockContext = createMockContext( {
+					autoplay: {
+						delay: 3000,
+						stopOnInteraction: true,
+						stopOnMouseEnter: false,
+					},
+				} );
+				const { wrapper, viewport } = createMockCarouselDOM();
+				const mockEmbla = createMockEmblaInstance();
+				const originalIntersectionObserver = window.IntersectionObserver;
+				const applyFilters = jest.fn( ( hookName, value ) => {
+					if ( hookName === 'rtcamp.carouselKit.emblaPlugins' ) {
+						return 'not-an-array';
+					}
+					return value;
+				} );
+
+				mockVisibleViewport( viewport );
+
+				( window as HooksWindow ).wp = {
+					hooks: {
+						applyFilters,
+					},
+				};
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: wrapper } );
+				( EmblaCarousel as unknown as jest.Mock ).mockReturnValue( mockEmbla );
+				delete ( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver;
+
+				try {
+					storeConfig.callbacks.initCarousel();
+
+					expect( EmblaCarousel ).toHaveBeenCalledWith(
+						viewport,
+						expect.any( Object ),
+						[ expect.objectContaining( { name: 'autoplay' } ) ],
+					);
+				} finally {
+					( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver =
+						originalIntersectionObserver;
+					delete ( window as HooksWindow ).wp;
+				}
+			} );
 		} );
 	} );
 } );

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -861,10 +861,10 @@ describe( 'Carousel View Module', () => {
 				mockVisibleViewport( viewport );
 
 				const applyFilters = jest.fn( ( hookName, value ) => {
-					if ( hookName === 'rtcamp.carouselKit.emblaOptions' ) {
+					if ( hookName === 'rtcamp.rtCarousel.emblaOptions' ) {
 						return { ...value, duration: 40 };
 					}
-					if ( hookName === 'rtcamp.carouselKit.emblaPlugins' ) {
+					if ( hookName === 'rtcamp.rtCarousel.emblaPlugins' ) {
 						return [ ...value, extraPlugin ];
 					}
 					return value;
@@ -888,7 +888,7 @@ describe( 'Carousel View Module', () => {
 					expect( applyFilters ).toHaveBeenCalledTimes( 2 );
 					expect( applyFilters ).toHaveBeenNthCalledWith(
 						1,
-						'rtcamp.carouselKit.emblaOptions',
+						'rtcamp.rtCarousel.emblaOptions',
 						expect.objectContaining( { duration: 25 } ),
 						expect.objectContaining( { context: mockContext, root: wrapper, viewport } ),
 					);
@@ -898,7 +898,7 @@ describe( 'Carousel View Module', () => {
 						[ extraPlugin ],
 					);
 					expect( doAction ).toHaveBeenCalledWith(
-						'rtcamp.carouselKit.emblaInit',
+						'rtcamp.rtCarousel.emblaInit',
 						mockEmbla,
 						expect.objectContaining( {
 							context: mockContext,
@@ -923,7 +923,7 @@ describe( 'Carousel View Module', () => {
 				const mockEmbla = createMockEmblaInstance();
 				const originalIntersectionObserver = window.IntersectionObserver;
 				const applyFilters = jest.fn( ( hookName, value ) => {
-					if ( hookName === 'rtcamp.carouselKit.emblaOptions' ) {
+					if ( hookName === 'rtcamp.rtCarousel.emblaOptions' ) {
 						return undefined;
 					}
 					return value;
@@ -968,7 +968,7 @@ describe( 'Carousel View Module', () => {
 				const mockEmbla = createMockEmblaInstance();
 				const originalIntersectionObserver = window.IntersectionObserver;
 				const applyFilters = jest.fn( ( hookName, value ) => {
-					if ( hookName === 'rtcamp.carouselKit.emblaPlugins' ) {
+					if ( hookName === 'rtcamp.rtCarousel.emblaPlugins' ) {
 						return 'not-an-array';
 					}
 					return value;

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -24,6 +24,15 @@ type EmblaViewportElement = HTMLElement & {
 	[EMBLA_KEY]?: EmblaCarouselType;
 };
 
+type HooksWindow = Window & {
+	wp?: {
+		hooks?: {
+			applyFilters?: jest.Mock;
+			doAction?: jest.Mock;
+		};
+	};
+};
+
 import type { CarouselContext } from '../types';
 
 // Import view to trigger store registration
@@ -90,6 +99,20 @@ const createMockCarouselDOM = () => {
 	return { wrapper, viewport, button };
 };
 
+const mockVisibleViewport = ( viewport: HTMLElement ) => {
+	viewport.getBoundingClientRect = jest.fn( () => ( {
+		width: 100,
+		height: 0,
+		top: 0,
+		right: 0,
+		bottom: 0,
+		left: 0,
+		x: 0,
+		y: 0,
+		toJSON: () => ( {} ),
+	} ) );
+};
+
 /**
  * Helper to create mock Embla instance with all required methods.
  *
@@ -107,6 +130,8 @@ const createMockEmblaInstance = ( overrides = {} ) => ( {
 	canScrollNext: jest.fn( () => true ),
 	selectedScrollSnap: jest.fn( () => 0 ),
 	scrollSnapList: jest.fn( () => [ 0, 0.5, 1 ] ),
+	scrollProgress: jest.fn( () => 0 ),
+	slideNodes: jest.fn( () => [] ),
 	...overrides,
 } );
 
@@ -798,17 +823,7 @@ describe( 'Carousel View Module', () => {
 					return mockEmbla;
 				} );
 
-				viewport.getBoundingClientRect = jest.fn( () => ( {
-					width: 100,
-					height: 0,
-					top: 0,
-					right: 0,
-					bottom: 0,
-					left: 0,
-					x: 0,
-					y: 0,
-					toJSON: () => ( {} ),
-				} ) );
+				mockVisibleViewport( viewport );
 
 				( getContext as jest.Mock ).mockReturnValue( mockContext );
 				( getElement as jest.Mock ).mockReturnValue( { ref: wrapper } );
@@ -826,6 +841,77 @@ describe( 'Carousel View Module', () => {
 				} finally {
 					( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver =
 						originalIntersectionObserver;
+				}
+			} );
+
+			it( 'should filter Embla options and plugins before initialization and fire init action', () => {
+				const mockContext = createMockContext( {
+					options: { duration: 25 },
+				} );
+				const { wrapper, viewport } = createMockCarouselDOM();
+				const mockEmbla = createMockEmblaInstance();
+				const originalIntersectionObserver = window.IntersectionObserver;
+				const extraPlugin = {
+					name: 'test-plugin',
+					options: {},
+					init: jest.fn(),
+					destroy: jest.fn(),
+				};
+
+				mockVisibleViewport( viewport );
+
+				const applyFilters = jest.fn( ( hookName, value ) => {
+					if ( hookName === 'rtcamp.carouselKit.emblaOptions' ) {
+						return { ...value, duration: 40 };
+					}
+					if ( hookName === 'rtcamp.carouselKit.emblaPlugins' ) {
+						return [ ...value, extraPlugin ];
+					}
+					return value;
+				} );
+				const doAction = jest.fn();
+
+				( window as HooksWindow ).wp = {
+					hooks: {
+						applyFilters,
+						doAction,
+					},
+				};
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: wrapper } );
+				( EmblaCarousel as unknown as jest.Mock ).mockReturnValue( mockEmbla );
+				delete ( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver;
+
+				try {
+					storeConfig.callbacks.initCarousel();
+
+					expect( applyFilters ).toHaveBeenCalledTimes( 2 );
+					expect( applyFilters ).toHaveBeenNthCalledWith(
+						1,
+						'rtcamp.carouselKit.emblaOptions',
+						expect.objectContaining( { duration: 25 } ),
+						expect.objectContaining( { context: mockContext, root: wrapper, viewport } ),
+					);
+					expect( EmblaCarousel ).toHaveBeenCalledWith(
+						viewport,
+						expect.objectContaining( { duration: 40 } ),
+						[ extraPlugin ],
+					);
+					expect( doAction ).toHaveBeenCalledWith(
+						'rtcamp.carouselKit.emblaInit',
+						mockEmbla,
+						expect.objectContaining( {
+							context: mockContext,
+							root: wrapper,
+							viewport,
+							options: expect.objectContaining( { duration: 40 } ),
+							plugins: [ extraPlugin ],
+						} ),
+					);
+				} finally {
+					( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver =
+						originalIntersectionObserver;
+					delete ( window as HooksWindow ).wp;
 				}
 			} );
 		} );

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -90,5 +90,6 @@
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css",
+	"viewScript": "wp-hooks",
 	"viewScriptModule": "file:./view.js"
 }

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -2,6 +2,7 @@ import { store, getContext, getElement } from '@wordpress/interactivity';
 import EmblaCarousel, {
 	type EmblaOptionsType,
 	type EmblaCarouselType,
+	type EmblaPluginType,
 } from 'embla-carousel';
 import Autoplay, { type AutoplayOptionsType } from 'embla-carousel-autoplay';
 import type { CarouselContext } from './types';
@@ -22,6 +23,57 @@ type EmblaViewportElement = HTMLElement & {
 };
 
 export const emblaInstances = new WeakMap<HTMLElement, EmblaCarouselType>();
+
+type EmblaFilterContext = {
+	context: CarouselContext;
+	root: HTMLElement;
+	viewport: HTMLElement;
+	dynamicListContainer: HTMLElement | null;
+	options?: EmblaOptionsType;
+};
+
+type HooksWindow = Window & {
+	wp?: {
+		hooks?: {
+			applyFilters?: (
+				hookName: string,
+				value: unknown,
+				...args: unknown[]
+			) => unknown;
+			doAction?: ( hookName: string, ...args: unknown[] ) => void;
+		};
+	};
+};
+
+const applyEmblaFilter = <T>(
+	hookName: string,
+	value: T,
+	filterContext: EmblaFilterContext,
+): T => {
+	const applyFilters = ( window as HooksWindow ).wp?.hooks?.applyFilters;
+
+	if ( typeof applyFilters !== 'function' ) {
+		return value;
+	}
+
+	return applyFilters( hookName, value, filterContext ) as T;
+};
+
+const doEmblaAction = (
+	hookName: string,
+	embla: EmblaCarouselType,
+	filterContext: EmblaFilterContext & {
+		plugins: EmblaPluginType[];
+	},
+): void => {
+	const doAction = ( window as HooksWindow ).wp?.hooks?.doAction;
+
+	if ( typeof doAction !== 'function' ) {
+		return;
+	}
+
+	doAction( hookName, embla, filterContext );
+};
 
 const getElementRef = ( rawElement: unknown ): HTMLElement | null => {
 	if ( rawElement instanceof HTMLElement ) {
@@ -304,13 +356,32 @@ store( 'rt-carousel/carousel', {
 						container: dynamicListContainer || null,
 					};
 
-					const plugins = [];
+					const plugins: EmblaPluginType[] = [];
 
 					if ( context.autoplay ) {
 						plugins.push( Autoplay( context.autoplay as AutoplayOptionsType ) );
 					}
 
-					const embla = EmblaCarousel( viewport, options, plugins );
+					const filterContext: EmblaFilterContext = {
+						context,
+						root: element,
+						viewport,
+						dynamicListContainer,
+					};
+
+					const filteredOptions = applyEmblaFilter(
+						'rtcamp.carouselKit.emblaOptions',
+						options,
+						filterContext,
+					);
+
+					const filteredPlugins = applyEmblaFilter(
+						'rtcamp.carouselKit.emblaPlugins',
+						plugins,
+						{ ...filterContext, options: filteredOptions },
+					);
+
+					const embla = EmblaCarousel( viewport, filteredOptions, filteredPlugins );
 
 					emblaInstances.set( viewport, embla );
 					viewport[ EMBLA_KEY ] = embla;
@@ -348,6 +419,15 @@ store( 'rt-carousel/carousel', {
 					} );
 
 					updateState();
+					doEmblaAction(
+						'rtcamp.carouselKit.emblaInit',
+						embla,
+						{
+							...filterContext,
+							options: filteredOptions,
+							plugins: filteredPlugins,
+						},
+					);
 
 					return () => {
 						embla.destroy();

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -371,13 +371,13 @@ store( 'rt-carousel/carousel', {
 					};
 
 					const filteredOptions = applyEmblaFilter(
-						'rtcamp.carouselKit.emblaOptions',
+						'rtcamp.rtCarousel.emblaOptions',
 						options,
 						filterContext,
 					);
 
 					const filteredPlugins = applyEmblaFilter(
-						'rtcamp.carouselKit.emblaPlugins',
+						'rtcamp.rtCarousel.emblaPlugins',
 						plugins,
 						{ ...filterContext, options: filteredOptions },
 					);
@@ -424,7 +424,7 @@ store( 'rt-carousel/carousel', {
 
 					updateState();
 					doEmblaAction(
-						'rtcamp.carouselKit.emblaInit',
+						'rtcamp.rtCarousel.emblaInit',
 						embla,
 						{
 							...filterContext,

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -56,7 +56,8 @@ const applyEmblaFilter = <T>(
 		return value;
 	}
 
-	return applyFilters( hookName, value, filterContext ) as T;
+	const result = applyFilters( hookName, value, filterContext );
+	return result !== null && result !== undefined ? ( result as T ) : value;
 };
 
 const doEmblaAction = (
@@ -380,8 +381,11 @@ store( 'rt-carousel/carousel', {
 						plugins,
 						{ ...filterContext, options: filteredOptions },
 					);
+					const safePlugins = Array.isArray( filteredPlugins )
+						? filteredPlugins
+						: plugins;
 
-					const embla = EmblaCarousel( viewport, filteredOptions, filteredPlugins );
+					const embla = EmblaCarousel( viewport, filteredOptions, safePlugins );
 
 					emblaInstances.set( viewport, embla );
 					viewport[ EMBLA_KEY ] = embla;
@@ -425,7 +429,7 @@ store( 'rt-carousel/carousel', {
 						{
 							...filterContext,
 							options: filteredOptions,
-							plugins: filteredPlugins,
+							plugins: safePlugins,
 						},
 					);
 


### PR DESCRIPTION
## Summary

Adds stable JavaScript hooks around rtCarousel's Embla initialization so projects can adjust Embla options, append Embla plugins, and access the initialized Embla API for methods and events without forking the plugin.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement/refactor
- [x] Documentation update
- [x] Test update
- [ ] Build/CI/tooling

## Related issue(s)

Closes #144

## What changed

- Added `rtcamp.carouselKit.emblaOptions` to filter the options passed to `EmblaCarousel`.
- Added `rtcamp.carouselKit.emblaPlugins` to filter the Embla plugin array after the built-in Autoplay plugin is configured.
- Added `rtcamp.carouselKit.emblaInit` so integrations can call Embla methods or subscribe to Embla events after initialization.
- Added API documentation and unit test coverage for the extension hooks.

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path:
- [x] No

## Testing

Describe how this was tested.

- [x] Unit tests
- [x] Manual testing - tested numerous previously unavailable options and all official and up-to-date third-party plugins.
- [ ] Cross-browser testing (if UI changes)

Test details:

- `npm run lint:js`
- `npm run lint:js:types`
- `npm run test:js -- --runTestsByPath src/blocks/carousel/__tests__/view.test.ts`
- `npm run build`
- Manually tested in a local WordPress install by adding site-level filters/actions for Embla options, plugins, methods, and events, including Auto Height, Auto Scroll, Class Names, Fade, Wheel Gestures, and A11y.

## Screenshots / recordings

Not applicable; this change exposes developer extension hooks and does not alter saved markup or default carousel behavior.

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added/updated tests where needed
- [x] I have updated docs where needed
- [x] I have checked for breaking changes
