### PR TITLE
Fix: account for gap in column block style width calculations

### DIFF
--- a/src/blocks/carousel/styles/_variants.scss
+++ b/src/blocks/carousel/styles/_variants.scss
@@ -6,19 +6,19 @@
 :where(.rt-carousel).is-style-columns-2,
 :where(.rt-carousel) .embla .wp-block-post-template.columns-2,
 :where(.rt-carousel) .embla .wp-block-term-template.columns-2 {
-	--rt-carousel-slide-width: 50%;
+	--rt-carousel-slide-width: calc((100% - (var(--rt-carousel-gap, 0px) * 1)) / 2);
 }
 
 /* 3 Columns */
 :where(.rt-carousel).is-style-columns-3,
 :where(.rt-carousel) .embla .wp-block-post-template.columns-3,
 :where(.rt-carousel) .embla .wp-block-term-template.columns-3 {
-	--rt-carousel-slide-width: 33.333%;
+	--rt-carousel-slide-width: calc((100% - (var(--rt-carousel-gap, 0px) * 2)) / 3);
 }
 
 /* 4 Columns */
 :where(.rt-carousel).is-style-columns-4,
 :where(.rt-carousel) .embla .wp-block-post-template.columns-4,
 :where(.rt-carousel) .embla .wp-block-term-template.columns-4 {
-	--rt-carousel-slide-width: 25%;
+	--rt-carousel-slide-width: calc((100% - (var(--rt-carousel-gap, 0px) * 3)) / 4);
 }


### PR DESCRIPTION
## Summary

The column block styles (2, 3, 4 columns) were using hardcoded percentage widths that didn't account for the slide gap, causing slides to overflow the carousel container when a gap was set.

Describe the change and why it is needed.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)
Closes #147

<!-- 'Closes' will automatically close the linked issue when this PR is merged. -->
<!-- 'Relates to' is for issues that are relevant but won't be closed by this PR. -->
Closes #<issue-number>
Relates to #<issue-number> (if applicable)

## What changed

Fixed slide width calculation in column styles to account for the configured gap value

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [X] No

## Testing

Describe how this was tested.

- [X] Unit tests
- [X] Manual testing
- [X] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

https://github.com/user-attachments/assets/54071396-0e20-48e2-8761-5c5e0d51cf47

<img width="830" height="545" alt="image" src="https://github.com/user-attachments/assets/ea280329-87e0-4c98-94d5-ed670d20b1de" />

## Checklist

- [X] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [X] I have checked for breaking changes
