### PR TITLE
feat: add Embla Auto Scroll plugin support with editor controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@wordpress/icons": "11.5.0",
         "@wordpress/interactivity": "6.37.0",
         "embla-carousel": "8.6.0",
+        "embla-carousel-auto-scroll": "8.6.0",
         "embla-carousel-autoplay": "8.6.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -4529,9 +4530,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4553,9 +4551,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4577,9 +4572,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4601,9 +4593,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4625,9 +4614,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4649,9 +4635,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7275,9 +7258,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7292,9 +7272,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7309,9 +7286,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7326,9 +7300,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7343,9 +7314,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7360,9 +7328,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7377,9 +7342,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7394,9 +7356,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12685,6 +12644,15 @@
     "node_modules/embla-carousel": {
       "version": "8.6.0",
       "license": "MIT"
+    },
+    "node_modules/embla-carousel-auto-scroll": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-auto-scroll/-/embla-carousel-auto-scroll-8.6.0.tgz",
+      "integrity": "sha512-WT9fWhNXFpbQ6kP+aS07oF5IHYLZ1Dx4DkwgCY8Hv2ZyYd2KMCPfMV1q/cA3wFGuLO7GMgKiySLX90/pQkcOdQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/embla-carousel-autoplay": {
       "version": "8.6.0",
@@ -23219,7 +23187,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@wordpress/icons": "11.5.0",
     "@wordpress/interactivity": "6.37.0",
     "embla-carousel": "8.6.0",
+    "embla-carousel-auto-scroll": "8.6.0",
     "embla-carousel-autoplay": "8.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/blocks/carousel/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/__tests__/edit.test.tsx
@@ -157,6 +157,12 @@ const createAttributes = (): CarouselAttributes => ( {
 	ariaLabel: 'Carousel',
 	slidesToScroll: '1',
 	slideGap: 0,
+	autoScroll: false,
+	autoScrollSpeed: 2,
+	autoScrollDirection: 'forward' as const,
+	autoScrollStartDelay: 1000,
+	autoScrollStopOnInteraction: true,
+	autoScrollStopOnMouseEnter: false,
 } );
 
 describe( 'Carousel Edit setup flow', () => {
@@ -217,4 +223,16 @@ describe( 'Carousel Edit setup flow', () => {
 			Object.defineProperty( globalThis, 'document', originalDocumentDescriptor );
 		}
 	} );
+
+	it( 'should have correct default autoScroll attributes', () => {
+		const attributes = createAttributes();
+		expect( attributes.autoScroll ).toBe( false );
+		expect( attributes.autoScrollSpeed ).toBe( 2 );
+		expect( attributes.autoScrollDirection ).toBe( 'forward' );
+		expect( attributes.autoScrollStartDelay ).toBe( 1000 );
+		expect( attributes.autoScrollStopOnInteraction ).toBe( true );
+		expect( attributes.autoScrollStopOnMouseEnter ).toBe( false );
+	} );
+
+
 } );

--- a/src/blocks/carousel/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/__tests__/edit.test.tsx
@@ -233,6 +233,4 @@ describe( 'Carousel Edit setup flow', () => {
 		expect( attributes.autoScrollStopOnInteraction ).toBe( true );
 		expect( attributes.autoScrollStopOnMouseEnter ).toBe( false );
 	} );
-
-
 } );

--- a/src/blocks/carousel/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/__tests__/edit.test.tsx
@@ -234,8 +234,8 @@ describe( 'Carousel Edit setup flow', () => {
 		expect( attributes.autoScrollStartDelay ).toBe( 1000 );
 		expect( attributes.autoScrollStopOnInteraction ).toBe( true );
 		expect( attributes.autoScrollStopOnMouseEnter ).toBe( false );
-	})
-	
+	} );
+
 	it( 'renders a Transition select and hides slide-only controls when fade is active', () => {
 		render(
 			<Edit

--- a/src/blocks/carousel/__tests__/types.test.ts
+++ b/src/blocks/carousel/__tests__/types.test.ts
@@ -33,6 +33,12 @@ describe( 'CarouselAttributes Type', () => {
 				ariaLabel: 'Image carousel',
 				slideGap: 16,
 				slidesToScroll: '1',
+				autoScroll: false,
+				autoScrollSpeed: 2,
+				autoScrollDirection: 'forward',
+				autoScrollStartDelay: 1000,
+				autoScrollStopOnInteraction: true,
+				autoScrollStopOnMouseEnter: false,
 			};
 
 			expect( attributes ).toBeDefined();
@@ -58,6 +64,12 @@ describe( 'CarouselAttributes Type', () => {
 				ariaLabel: '',
 				slideGap: 0,
 				slidesToScroll: 'auto',
+				autoScroll: false,
+				autoScrollSpeed: 2,
+				autoScrollDirection: 'forward',
+				autoScrollStartDelay: 1000,
+				autoScrollStopOnInteraction: true,
+				autoScrollStopOnMouseEnter: false,
 			};
 
 			// Verify all keys exist
@@ -254,6 +266,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0,
 				slideCount: 2,
 				ariaLabelPattern: 'Go to slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.autoplay ).toBe( false );
@@ -280,6 +293,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0.5,
 				slideCount: 3,
 				ariaLabelPattern: 'Slide %d of 3',
+				autoScroll: false,
 			};
 
 			expect( context.autoplay ).not.toBe( false );
@@ -307,6 +321,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0,
 				slideCount: 3,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.selectedIndex ).toBe( 0 );
@@ -327,6 +342,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0.5,
 				slideCount: 3,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.selectedIndex ).toBe( 1 );
@@ -347,6 +363,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 1,
 				slideCount: 3,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.selectedIndex ).toBe( 2 );
@@ -367,6 +384,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0,
 				slideCount: 1,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.scrollSnaps ).toHaveLength( 1 );
@@ -389,6 +407,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0,
 				slideCount: 1,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.timerIterationId ).toBe( 5 );
@@ -411,6 +430,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0,
 				slideCount: 0,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.timerIterationId ).toBe( 0 );
@@ -434,6 +454,7 @@ describe( 'CarouselContext Type', () => {
 				slideCount: 0,
 				ariaLabelPattern: 'Slide %d',
 				ref: element,
+				autoScroll: false,
 			};
 
 			expect( context.ref ).toBe( element );
@@ -454,6 +475,7 @@ describe( 'CarouselContext Type', () => {
 				slideCount: 0,
 				ariaLabelPattern: 'Slide %d',
 				ref: null,
+				autoScroll: false,
 			};
 
 			expect( context.ref ).toBeNull();
@@ -472,6 +494,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0,
 				slideCount: 0,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.ref ).toBeUndefined();
@@ -495,6 +518,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0,
 				slideCount: 0,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.options.slidesToScroll ).toBe( 2 );
@@ -516,6 +540,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0,
 				slideCount: 0,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.options.slidesToScroll ).toBe( 'auto' );
@@ -544,6 +569,7 @@ describe( 'CarouselContext Type', () => {
 					scrollProgress: 0,
 					slideCount: 0,
 					ariaLabelPattern: pattern,
+					autoScroll: false,
 				};
 
 				expect( context.ariaLabelPattern ).toBe( pattern );
@@ -565,6 +591,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0,
 				slideCount: 0,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.scrollSnaps ).toHaveLength( 0 );
@@ -591,6 +618,7 @@ describe( 'CarouselContext Type', () => {
 				scrollProgress: 0,
 				slideCount: 5,
 				ariaLabelPattern: 'Slide %d',
+				autoScroll: false,
 			};
 
 			expect( context.scrollSnaps ).toHaveLength( 5 );

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -68,6 +68,7 @@ const createMockContext = (
 	scrollProgress: 0,
 	slideCount: 3,
 	ariaLabelPattern: 'Go to slide %d',
+	autoScroll: false,
 	...overrides,
 } );
 
@@ -1009,5 +1010,35 @@ describe( 'Edge Cases and Error Handling', () => {
 
 		expect( mockContext.scrollSnaps ).toHaveLength( 100 );
 		expect( mockContext.selectedIndex ).toBe( 50 );
+	} );
+
+	it( 'should handle autoScroll configuration', () => {
+		const mockContextWithAutoScroll = createMockContext( {
+			autoScroll: {
+				speed: 3,
+				direction: 'forward',
+				startDelay: 500,
+				stopOnInteraction: false,
+				stopOnMouseEnter: true,
+				stopOnFocusIn: false,
+			},
+		} );
+
+		expect( mockContextWithAutoScroll.autoScroll ).toEqual( {
+			speed: 3,
+			direction: 'forward',
+			startDelay: 500,
+			stopOnInteraction: false,
+			stopOnMouseEnter: true,
+			stopOnFocusIn: false,
+		} );
+	} );
+
+	it( 'should handle autoScroll disabled', () => {
+		const mockContext = createMockContext( {
+			autoScroll: false,
+		} );
+
+		expect( mockContext.autoScroll ).toBe( false );
 	} );
 } );

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -93,6 +93,11 @@
 		"autoScrollSpeed": {
 			"type": "number",
 			"default": 2
+		},
+		"autoScrollDirection": {
+			"type": "string",
+			"default": "ltr",
+			"enum": ["forward", "backward"]
 		}
 	},
 	"editorScript": "file:./index.js",

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -102,6 +102,10 @@
 		"autoScrollStartDelay": {
 			"type": "number",
 			"default": 1000
+		},
+		"autoScrollStopOnInteraction": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"editorScript": "file:./index.js",

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -106,6 +106,10 @@
 		"autoScrollStopOnInteraction": {
 			"type": "boolean",
 			"default": true
+		},
+		"autoScrollStopOnMouseEnter": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"editorScript": "file:./index.js",

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -85,6 +85,10 @@
 		"slidesToScroll": {
 			"type": "string",
 			"default": "1"
+		},
+		"autoScroll": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"editorScript": "file:./index.js",

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -98,6 +98,10 @@
 			"type": "string",
 			"default": "ltr",
 			"enum": ["forward", "backward"]
+		},
+		"autoScrollStartDelay": {
+			"type": "number",
+			"default": 1000
 		}
 	},
 	"editorScript": "file:./index.js",

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -89,6 +89,10 @@
 		"autoScroll": {
 			"type": "boolean",
 			"default": false
+		},
+		"autoScrollSpeed": {
+			"type": "number",
+			"default": 2
 		}
 	},
 	"editorScript": "file:./index.js",

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -101,7 +101,7 @@
 		},
 		"autoScrollDirection": {
 			"type": "string",
-			"default": "ltr",
+			"default": "forward",
 			"enum": ["forward", "backward"]
 		},
 		"autoScrollStartDelay": {

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -57,7 +57,8 @@ export default function Edit( {
 		autoScroll,
 		autoScrollSpeed,
 		autoScrollDirection,
-		autoScrollStartDelay
+		autoScrollStartDelay,
+		autoScrollStopOnInteraction
 	} = attributes;
 
 	const [ emblaApi, setEmblaApi ] = useState<EmblaCarouselType | undefined>();
@@ -514,6 +515,14 @@ export default function Edit( {
 						min={ 0 }
 						max={ 10000 }
 						step={ 100 }
+					/>
+					<ToggleControl
+						label={ __( 'Stop on Interaction', 'rt-carousel' ) }
+						checked={ autoScrollStopOnInteraction }
+						onChange={ ( value ) =>
+							setAttributes( { autoScrollStopOnInteraction: value } )
+						}
+						help={ __( 'Stop auto scroll when user interacts with carousel.', 'rt-carousel' ) }
 					/>
 				 </> ) }
 				</PanelBody>

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -54,6 +54,7 @@ export default function Edit( {
 		autoplayStopOnMouseEnter,
 		ariaLabel,
 		slidesToScroll = '1',
+		autoScroll,
 	} = attributes;
 
 	const [ emblaApi, setEmblaApi ] = useState<EmblaCarouselType | undefined>();
@@ -421,7 +422,12 @@ export default function Edit( {
 					<ToggleControl
 						label={ __( 'Enable Autoplay', 'rt-carousel' ) }
 						checked={ autoplay }
-						onChange={ ( value ) => setAttributes( { autoplay: value } ) }
+						onChange={ ( value ) => {
+							setAttributes( { 
+								autoplay: value,
+								autoScroll: value ? false : autoScroll,
+							 } ) 
+						}}
 					/>
 					{ autoplay && (
 						<>
@@ -459,6 +465,20 @@ export default function Edit( {
 							/>
 						</>
 					) }
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Auto Scroll', 'rt-carousel' ) }
+					initialOpen={ false }
+				>
+				<ToggleControl
+					label={ __( 'Enable Auto Scroll', 'rt-carousel' ) }
+					checked={ autoScroll }
+					onChange={ ( value ) => setAttributes( {
+						autoScroll: value,
+						autoplay: value ? false : autoplay,
+					} ) }
+				/>
+
 				</PanelBody>
 			</InspectorControls>
 			<InspectorAdvancedControls>

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -56,6 +56,7 @@ export default function Edit( {
 		slidesToScroll = '1',
 		autoScroll,
 		autoScrollSpeed,
+		autoScrollDirection
 	} = attributes;
 
 	const [ emblaApi, setEmblaApi ] = useState<EmblaCarouselType | undefined>();
@@ -488,6 +489,17 @@ export default function Edit( {
 						}
 						min={ 1 }
 						max={ 10 }
+					/>
+					<SelectControl
+						label={ __( 'Direction', 'rt-carousel' ) }
+						value={ autoScrollDirection }
+						options={ [
+							{ label: __( 'Forward', 'rt-carousel' ), value: 'forward' },
+							{ label: __( 'Backward', 'rt-carousel' ), value: 'backward' },
+						] }
+						onChange={ ( value ) =>
+							setAttributes( { autoScrollDirection: value as  CarouselAttributes['autoScrollDirection']} )
+						}
 					/>
 				 </> ) }
 				</PanelBody>

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -56,7 +56,8 @@ export default function Edit( {
 		slidesToScroll = '1',
 		autoScroll,
 		autoScrollSpeed,
-		autoScrollDirection
+		autoScrollDirection,
+		autoScrollStartDelay
 	} = attributes;
 
 	const [ emblaApi, setEmblaApi ] = useState<EmblaCarouselType | undefined>();
@@ -503,6 +504,16 @@ export default function Edit( {
 								loop: value === 'backward' ? true : loop,
 							} )
 						}
+					/>
+					<RangeControl
+						label={ __( 'Start Delay (ms)', 'rt-carousel' ) }
+						value={ autoScrollStartDelay }
+						onChange={ ( value ) =>
+							setAttributes( { autoScrollStartDelay: value ?? 1000 } )
+						}
+						min={ 0 }
+						max={ 10000 }
+						step={ 100 }
 					/>
 				 </> ) }
 				</PanelBody>

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -317,11 +317,11 @@ export default function Edit( {
 					<ToggleControl
 						label={ __( 'Loop', 'rt-carousel' ) }
 						checked={ loop }
+						disabled={ autoScrollDirection === 'backward' }
 						onChange={ ( value ) => setAttributes( { loop: value } ) }
-						help={ __(
-							'Enables infinite scrolling of slides.',
-							'rt-carousel',
-						) }
+						help={ autoScrollDirection === 'backward' 
+								? __( 'Loop is required for backward auto scroll.', 'rt-carousel' )
+								: __( 'Enables infinite scrolling of slides.', 'rt-carousel' ) }
 					/>
 					<ToggleControl
 						label={ __( 'Free Drag', 'rt-carousel' ) }
@@ -498,7 +498,10 @@ export default function Edit( {
 							{ label: __( 'Backward', 'rt-carousel' ), value: 'backward' },
 						] }
 						onChange={ ( value ) =>
-							setAttributes( { autoScrollDirection: value as  CarouselAttributes['autoScrollDirection']} )
+							setAttributes( { 
+								autoScrollDirection: value as  CarouselAttributes['autoScrollDirection'],
+								loop: value === 'backward' ? true : loop,
+							} )
 						}
 					/>
 				 </> ) }

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -55,6 +55,7 @@ export default function Edit( {
 		ariaLabel,
 		slidesToScroll = '1',
 		autoScroll,
+		autoScrollSpeed,
 	} = attributes;
 
 	const [ emblaApi, setEmblaApi ] = useState<EmblaCarouselType | undefined>();
@@ -478,7 +479,17 @@ export default function Edit( {
 						autoplay: value ? false : autoplay,
 					} ) }
 				/>
-
+				{ autoScroll && ( <> 
+					<RangeControl
+						label={ __( 'Speed', 'rt-carousel' ) }
+						value={ autoScrollSpeed }
+						onChange={ ( value ) =>
+							setAttributes( { autoScrollSpeed: value ?? 2 } )
+						}
+						min={ 1 }
+						max={ 10 }
+					/>
+				 </> ) }
 				</PanelBody>
 			</InspectorControls>
 			<InspectorAdvancedControls>

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -58,7 +58,8 @@ export default function Edit( {
 		autoScrollSpeed,
 		autoScrollDirection,
 		autoScrollStartDelay,
-		autoScrollStopOnInteraction
+		autoScrollStopOnInteraction,
+		autoScrollStopOnMouseEnter
 	} = attributes;
 
 	const [ emblaApi, setEmblaApi ] = useState<EmblaCarouselType | undefined>();
@@ -523,6 +524,14 @@ export default function Edit( {
 							setAttributes( { autoScrollStopOnInteraction: value } )
 						}
 						help={ __( 'Stop auto scroll when user interacts with carousel.', 'rt-carousel' ) }
+					/>
+					<ToggleControl
+						label={ __( 'Stop on Mouse Enter', 'rt-carousel' ) }
+						checked={ autoScrollStopOnMouseEnter }
+						onChange={ ( value ) =>
+							setAttributes( { autoScrollStopOnMouseEnter: value } )
+						}
+						help={ __( 'Stop auto scroll when mouse hovers over carousel.', 'rt-carousel' ) }
 					/>
 				 </> ) }
 				</PanelBody>

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -506,7 +506,7 @@ export default function Edit( {
 						onChange={ ( value ) => setAttributes( {
 							autoScroll: value,
 							autoplay: value ? false : autoplay,
-							loop: autoScrollDirection === 'backward' ? true : loop,
+							loop: ( value && autoScrollDirection === 'backward' ) ? true : loop,
 						} ) }
 					/>
 					{ autoScroll && ( <>

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -59,7 +59,7 @@ export default function Edit( {
 		autoScrollDirection,
 		autoScrollStartDelay,
 		autoScrollStopOnInteraction,
-		autoScrollStopOnMouseEnter
+		autoScrollStopOnMouseEnter,
 	} = attributes;
 
 	const [ emblaApi, setEmblaApi ] = useState<EmblaCarouselType | undefined>();
@@ -322,9 +322,9 @@ export default function Edit( {
 						checked={ loop }
 						disabled={ autoScrollDirection === 'backward' }
 						onChange={ ( value ) => setAttributes( { loop: value } ) }
-						help={ autoScrollDirection === 'backward' 
-								? __( 'Loop is required for backward auto scroll.', 'rt-carousel' )
-								: __( 'Enables infinite scrolling of slides.', 'rt-carousel' ) }
+						help={ autoScrollDirection === 'backward'
+							? __( 'Loop is required for backward auto scroll.', 'rt-carousel' )
+							: __( 'Enables infinite scrolling of slides.', 'rt-carousel' ) }
 					/>
 					<ToggleControl
 						label={ __( 'Free Drag', 'rt-carousel' ) }
@@ -428,11 +428,11 @@ export default function Edit( {
 						label={ __( 'Enable Autoplay', 'rt-carousel' ) }
 						checked={ autoplay }
 						onChange={ ( value ) => {
-							setAttributes( { 
+							setAttributes( {
 								autoplay: value,
 								autoScroll: value ? false : autoScroll,
-							 } ) 
-						}}
+							} );
+						} }
 					/>
 					{ autoplay && (
 						<>
@@ -475,65 +475,65 @@ export default function Edit( {
 					title={ __( 'Auto Scroll', 'rt-carousel' ) }
 					initialOpen={ false }
 				>
-				<ToggleControl
-					label={ __( 'Enable Auto Scroll', 'rt-carousel' ) }
-					checked={ autoScroll }
-					onChange={ ( value ) => setAttributes( {
-						autoScroll: value,
-						autoplay: value ? false : autoplay,
-					} ) }
-				/>
-				{ autoScroll && ( <> 
-					<RangeControl
-						label={ __( 'Speed', 'rt-carousel' ) }
-						value={ autoScrollSpeed }
-						onChange={ ( value ) =>
-							setAttributes( { autoScrollSpeed: value ?? 2 } )
-						}
-						min={ 1 }
-						max={ 10 }
-					/>
-					<SelectControl
-						label={ __( 'Direction', 'rt-carousel' ) }
-						value={ autoScrollDirection }
-						options={ [
-							{ label: __( 'Forward', 'rt-carousel' ), value: 'forward' },
-							{ label: __( 'Backward', 'rt-carousel' ), value: 'backward' },
-						] }
-						onChange={ ( value ) =>
-							setAttributes( { 
-								autoScrollDirection: value as  CarouselAttributes['autoScrollDirection'],
-								loop: value === 'backward' ? true : loop,
-							} )
-						}
-					/>
-					<RangeControl
-						label={ __( 'Start Delay (ms)', 'rt-carousel' ) }
-						value={ autoScrollStartDelay }
-						onChange={ ( value ) =>
-							setAttributes( { autoScrollStartDelay: value ?? 1000 } )
-						}
-						min={ 0 }
-						max={ 10000 }
-						step={ 100 }
-					/>
 					<ToggleControl
-						label={ __( 'Stop on Interaction', 'rt-carousel' ) }
-						checked={ autoScrollStopOnInteraction }
-						onChange={ ( value ) =>
-							setAttributes( { autoScrollStopOnInteraction: value } )
-						}
-						help={ __( 'Stop auto scroll when user interacts with carousel.', 'rt-carousel' ) }
+						label={ __( 'Enable Auto Scroll', 'rt-carousel' ) }
+						checked={ autoScroll }
+						onChange={ ( value ) => setAttributes( {
+							autoScroll: value,
+							autoplay: value ? false : autoplay,
+						} ) }
 					/>
-					<ToggleControl
-						label={ __( 'Stop on Mouse Enter', 'rt-carousel' ) }
-						checked={ autoScrollStopOnMouseEnter }
-						onChange={ ( value ) =>
-							setAttributes( { autoScrollStopOnMouseEnter: value } )
-						}
-						help={ __( 'Stop auto scroll when mouse hovers over carousel.', 'rt-carousel' ) }
-					/>
-				 </> ) }
+					{ autoScroll && ( <>
+						<RangeControl
+							label={ __( 'Speed', 'rt-carousel' ) }
+							value={ autoScrollSpeed }
+							onChange={ ( value ) =>
+								setAttributes( { autoScrollSpeed: value ?? 2 } )
+							}
+							min={ 1 }
+							max={ 10 }
+						/>
+						<SelectControl
+							label={ __( 'Direction', 'rt-carousel' ) }
+							value={ autoScrollDirection }
+							options={ [
+								{ label: __( 'Forward', 'rt-carousel' ), value: 'forward' },
+								{ label: __( 'Backward', 'rt-carousel' ), value: 'backward' },
+							] }
+							onChange={ ( value ) =>
+								setAttributes( {
+									autoScrollDirection: value as CarouselAttributes['autoScrollDirection'],
+									loop: value === 'backward' ? true : loop,
+								} )
+							}
+						/>
+						<RangeControl
+							label={ __( 'Start Delay (ms)', 'rt-carousel' ) }
+							value={ autoScrollStartDelay }
+							onChange={ ( value ) =>
+								setAttributes( { autoScrollStartDelay: value ?? 1000 } )
+							}
+							min={ 0 }
+							max={ 10000 }
+							step={ 100 }
+						/>
+						<ToggleControl
+							label={ __( 'Stop on Interaction', 'rt-carousel' ) }
+							checked={ autoScrollStopOnInteraction }
+							onChange={ ( value ) =>
+								setAttributes( { autoScrollStopOnInteraction: value } )
+							}
+							help={ __( 'Stop auto scroll when user interacts with carousel.', 'rt-carousel' ) }
+						/>
+						<ToggleControl
+							label={ __( 'Stop on Mouse Enter', 'rt-carousel' ) }
+							checked={ autoScrollStopOnMouseEnter }
+							onChange={ ( value ) =>
+								setAttributes( { autoScrollStopOnMouseEnter: value } )
+							}
+							help={ __( 'Stop auto scroll when mouse hovers over carousel.', 'rt-carousel' ) }
+						/>
+					</> ) }
 				</PanelBody>
 			</InspectorControls>
 			<InspectorAdvancedControls>

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -337,9 +337,9 @@ export default function Edit( {
 					<ToggleControl
 						label={ __( 'Loop', 'rt-carousel' ) }
 						checked={ loop }
-						disabled={ autoScrollDirection === 'backward' }
+						disabled={ autoScroll && autoScrollDirection === 'backward' }
 						onChange={ ( value ) => setAttributes( { loop: value } ) }
-						help={ autoScrollDirection === 'backward'
+						help={ autoScroll && autoScrollDirection === 'backward'
 							? __( 'Loop is required for backward auto scroll.', 'rt-carousel' )
 							: __( 'Enables infinite scrolling of slides.', 'rt-carousel' ) }
 					/>
@@ -506,6 +506,7 @@ export default function Edit( {
 						onChange={ ( value ) => setAttributes( {
 							autoScroll: value,
 							autoplay: value ? false : autoplay,
+							loop: autoScrollDirection === 'backward' ? true : loop,
 						} ) }
 					/>
 					{ autoScroll && ( <>

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -27,6 +27,7 @@ export default function Save( {
 		autoScrollDirection,
 		autoScrollStartDelay,
 		autoScrollStopOnInteraction,
+		autoScrollStopOnMouseEnter,
 	} = attributes;
 
 	// Pass configuration to the frontend via data-wp-context
@@ -74,7 +75,7 @@ export default function Save( {
 			direction: autoScrollDirection,
 			startDelay: autoScrollStartDelay,
 			stopOnInteraction: autoScrollStopOnInteraction,
-			stopOnMouseEnter: false,
+			stopOnMouseEnter: autoScrollStopOnMouseEnter,
 			stopOnFocusIn: true,
 		}
 		: false,

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -25,7 +25,8 @@ export default function Save( {
 		autoScroll,
 		autoScrollSpeed,
 		autoScrollDirection,
-		autoScrollStartDelay
+		autoScrollStartDelay,
+		autoScrollStopOnInteraction,
 	} = attributes;
 
 	// Pass configuration to the frontend via data-wp-context
@@ -72,7 +73,7 @@ export default function Save( {
 			speed: autoScrollSpeed,
 			direction: autoScrollDirection,
 			startDelay: autoScrollStartDelay,
-			stopOnInteraction: true,
+			stopOnInteraction: autoScrollStopOnInteraction,
 			stopOnMouseEnter: false,
 			stopOnFocusIn: true,
 		}

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -23,6 +23,7 @@ export default function Save( {
 		height,
 		slidesToScroll,
 		autoScroll,
+		autoScrollSpeed,
 	} = attributes;
 
 	// Pass configuration to the frontend via data-wp-context
@@ -66,7 +67,7 @@ export default function Save( {
 			'rt-carousel',
 		),
 		autoScroll: autoScroll ? {
-			speed: 2,
+			speed: autoScrollSpeed,
 			direction: 'forward',
 			startDelay: 1000,
 			stopOnInteraction: true,

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -24,6 +24,7 @@ export default function Save( {
 		slidesToScroll,
 		autoScroll,
 		autoScrollSpeed,
+		autoScrollDirection
 	} = attributes;
 
 	// Pass configuration to the frontend via data-wp-context
@@ -68,7 +69,7 @@ export default function Save( {
 		),
 		autoScroll: autoScroll ? {
 			speed: autoScrollSpeed,
-			direction: 'forward',
+			direction: autoScrollDirection,
 			startDelay: 1000,
 			stopOnInteraction: true,
 			stopOnMouseEnter: false,

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -22,6 +22,7 @@ export default function Save( {
 		axis,
 		height,
 		slidesToScroll,
+		autoScroll,
 	} = attributes;
 
 	// Pass configuration to the frontend via data-wp-context
@@ -64,6 +65,15 @@ export default function Save( {
 			'Slide {{currentSlide}} of {{totalSlides}}',
 			'rt-carousel',
 		),
+		autoScroll: autoScroll ? {
+			speed: 2,
+			direction: 'forward',
+			startDelay: 1000,
+			stopOnInteraction: true,
+			stopOnMouseEnter: false,
+			stopOnFocusIn: true,
+		}
+		: false,
 	};
 
 	const blockProps = useBlockProps.save( {

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -24,7 +24,8 @@ export default function Save( {
 		slidesToScroll,
 		autoScroll,
 		autoScrollSpeed,
-		autoScrollDirection
+		autoScrollDirection,
+		autoScrollStartDelay
 	} = attributes;
 
 	// Pass configuration to the frontend via data-wp-context
@@ -70,7 +71,7 @@ export default function Save( {
 		autoScroll: autoScroll ? {
 			speed: autoScrollSpeed,
 			direction: autoScrollDirection,
-			startDelay: 1000,
+			startDelay: autoScrollStartDelay,
 			stopOnInteraction: true,
 			stopOnMouseEnter: false,
 			stopOnFocusIn: true,

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -78,7 +78,7 @@ export default function Save( {
 			stopOnMouseEnter: autoScrollStopOnMouseEnter,
 			stopOnFocusIn: true,
 		}
-		: false,
+			: false,
 	};
 
 	const blockProps = useBlockProps.save( {

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -19,6 +19,7 @@ export type CarouselAttributes = {
 	slideGap: number;
 	slidesToScroll: string;
 	autoScroll: boolean;
+	autoScrollSpeed: number;
 };
 
 export type CarouselViewportAttributes = Record<string, never>;

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -23,6 +23,7 @@ export type CarouselAttributes = {
 	autoScrollDirection: 'forward' | 'backward';
 	autoScrollStartDelay: number;
 	autoScrollStopOnInteraction: boolean;
+	autoScrollStopOnMouseEnter: boolean;
 };
 
 export type CarouselViewportAttributes = Record<string, never>;

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -20,6 +20,7 @@ export type CarouselAttributes = {
 	slidesToScroll: string;
 	autoScroll: boolean;
 	autoScrollSpeed: number;
+	autoScrollDirection: 'forward' | 'backward';
 };
 
 export type CarouselViewportAttributes = Record<string, never>;

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -66,4 +66,12 @@ export type CarouselContext = {
 	ref?: HTMLElement | null;
 	slideCount: number;
 	initialized?: boolean;
+	autoScroll: boolean | {
+		speed: number;
+		direction: 'forward' | 'backward';
+		startDelay: number;
+		stopOnInteraction: boolean;
+		stopOnMouseEnter: boolean;
+		stopOnFocusIn: boolean;
+	};
 };

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -18,6 +18,7 @@ export type CarouselAttributes = {
 	ariaLabel: string;
 	slideGap: number;
 	slidesToScroll: string;
+	autoScroll: boolean;
 };
 
 export type CarouselViewportAttributes = Record<string, never>;

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -21,6 +21,7 @@ export type CarouselAttributes = {
 	autoScroll: boolean;
 	autoScrollSpeed: number;
 	autoScrollDirection: 'forward' | 'backward';
+	autoScrollStartDelay: number;
 };
 
 export type CarouselViewportAttributes = Record<string, never>;

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -22,6 +22,7 @@ export type CarouselAttributes = {
 	autoScrollSpeed: number;
 	autoScrollDirection: 'forward' | 'backward';
 	autoScrollStartDelay: number;
+	autoScrollStopOnInteraction: boolean;
 };
 
 export type CarouselViewportAttributes = Record<string, never>;

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -4,6 +4,8 @@ import EmblaCarousel, {
 	type EmblaCarouselType,
 } from 'embla-carousel';
 import Autoplay, { type AutoplayOptionsType } from 'embla-carousel-autoplay';
+import AutoScroll, { type AutoScrollOptionsType } from 'embla-carousel-auto-scroll';
+
 import type { CarouselContext } from './types';
 import {
 	DYNAMIC_LIST_CONTAINER_SELECTOR,
@@ -308,6 +310,10 @@ store( 'rt-carousel/carousel', {
 
 					if ( context.autoplay ) {
 						plugins.push( Autoplay( context.autoplay as AutoplayOptionsType ) );
+					}
+
+					if (context.autoScroll) {
+						plugins.push( AutoScroll( context.autoScroll as AutoScrollOptionsType) );
 					}
 
 					const embla = EmblaCarousel( viewport, options, plugins );

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -312,8 +312,8 @@ store( 'rt-carousel/carousel', {
 						plugins.push( Autoplay( context.autoplay as AutoplayOptionsType ) );
 					}
 
-					if (context.autoScroll) {
-						plugins.push( AutoScroll( context.autoScroll as AutoScrollOptionsType) );
+					if ( context.autoScroll ) {
+						plugins.push( AutoScroll( context.autoScroll as AutoScrollOptionsType ) );
 					}
 
 					const embla = EmblaCarousel( viewport, options, plugins );


### PR DESCRIPTION
## Summary

Describe the change and why it is needed.

Adds first-class support for Embla's Auto Scroll plugin so rtCarousel can create smooth, continuous scrolling carousels in addition to the existing slide-by-slide Autoplay behavior.
rtCarousel already supports many Embla predefined examples including loop, RTL, slides to scroll, drag free, alignment, y-axis, autoplay, dots, controls, counter, and progress. However, continuous scrolling via the Auto Scroll plugin was not yet supported.
The existing Autoplay feature advances one snap at a time after a delay — ideal for hero sliders and testimonials. Auto Scroll fills the gap for logo strips, partner showcases, announcement tickers, and marquee-style carousels where users expect continuous motion.

## Type of change

- [ ] Bug fix
- [X] New feature
- [X] Enhancement/refactor
- [ ] Documentation update
- [X] Test update
- [ ] Build/CI/tooling

## Related issue(s)

<!-- 'Closes' will automatically close the linked issue when this PR is merged. -->
<!-- 'Relates to' is for issues that are relevant but won't be closed by this PR. -->
Closes #146

Relates to #<issue-number> (if applicable)

## What changed

- Installed `embla-carousel-auto-scroll` package and imported `AutoScroll` plugin in `view.ts`
- Added 6 new block attributes: `autoScroll`, `autoScrollSpeed`, `autoScrollDirection`, `autoScrollStartDelay`, `autoScrollStopOnInteraction`, `autoScrollStopOnMouseEnter`
- Added "Auto Scroll" inspector panel with all editor controls (toggle, speed, direction, start delay, stop on interaction, stop on mouse enter)
- Auto Scroll and Autoplay are mutually exclusive — enabling one disables the other
- Enabling "Backward" direction automatically enables Loop (required for continuous backward scrolling)
- Loop toggle is disabled when direction is Backward, with contextual help text
- Updated `save.tsx` to pass Auto Scroll config to frontend via `data-wp-context`
- Updated `CarouselContext` and `CarouselAttributes` types in `types.ts`
- Added unit tests for Auto Scroll context configuration in `view.test.ts` and `edit.test.tsx`

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [X] No

## Testing

Describe how this was tested.

- [X] Unit tests
- [X] Manual testing
- [X] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

Uploading compressed Screen Recording 2026-06-06 at 7.mp4…

## Checklist

- [X] I have self-reviewed this PR
- [x] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
