### PR TITLE
chore: prepare for release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.0.2](https://github.com/rtCamp/rt-carousel/compare/2.0.1...2.0.2) (2026-06-04)
+
+
+### Features
+
+* add accessible Carousel Counter block ([#139](https://github.com/rtCamp/rt-carousel/pull/139)) ([49fd86b](https://github.com/rtCamp/rt-carousel/commit/49fd86b))
+* add slide template picker and starter templates for carousel block ([#83](https://github.com/rtCamp/rt-carousel/pull/83)) ([dd90468](https://github.com/rtCamp/rt-carousel/commit/dd90468))
+* add Terms Query support and Terms Query carousel pattern ([#131](https://github.com/rtCamp/rt-carousel/pull/131)) ([b0cf807](https://github.com/rtCamp/rt-carousel/commit/b0cf807))
+
+
+### Chores
+
+* confirm compatibility with WordPress 7.0
+* update axios from 1.15.0 to 1.16.0 ([#136](https://github.com/rtCamp/rt-carousel/pull/136)) ([6073e39](https://github.com/rtCamp/rt-carousel/commit/6073e39))
+* update fast-uri from 3.1.0 to 3.1.2 ([#137](https://github.com/rtCamp/rt-carousel/pull/137)) ([4762978](https://github.com/rtCamp/rt-carousel/commit/4762978))
+* update ip-address from 10.1.0 to 10.2.0 ([#135](https://github.com/rtCamp/rt-carousel/pull/135)) ([98ddd50](https://github.com/rtCamp/rt-carousel/commit/98ddd50))
+* update postcss from 8.5.6 to 8.5.13 ([#132](https://github.com/rtCamp/rt-carousel/pull/132)) ([0093274](https://github.com/rtCamp/rt-carousel/commit/0093274))
+
+
 ## [2.0.1](https://github.com/rtCamp/rt-carousel/compare/v2.0.0...v2.0.1) (2026-05-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.0.2](https://github.com/rtCamp/rt-carousel/compare/2.0.1...2.0.2) (2026-06-04)
+## [2.0.2](https://github.com/rtCamp/rt-carousel/compare/2.0.1...2.0.2) (2026-06-08)
 
 
 ### Features
@@ -10,7 +10,7 @@
 * add Terms Query support and Terms Query carousel pattern ([#131](https://github.com/rtCamp/rt-carousel/pull/131)) ([b0cf807](https://github.com/rtCamp/rt-carousel/commit/b0cf807))
 
 
-### Chores
+### Maintenance
 
 * confirm compatibility with WordPress 7.0
 * update axios from 1.15.0 to 1.16.0 ([#136](https://github.com/rtCamp/rt-carousel/pull/136)) ([6073e39](https://github.com/rtCamp/rt-carousel/commit/6073e39))

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # rtCarousel
 
+![rtCarousel banner](wp-assets/banner-1544x500.png)
+
 ![Build Status](https://github.com/rtCamp/rt-carousel/actions/workflows/release.yml/badge.svg?branch=main)
 ![Latest Release](https://img.shields.io/github/v/release/rtCamp/rt-carousel)
+![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/rt-carousel)
 
 **A modular, high-performance carousel block for WordPress, powered by the Interactivity API and Embla Carousel.**
+
+[View on WordPress.org](https://wordpress.org/plugins/rt-carousel/)
 
 Easily create dynamic, accessible, and customizable carousels for any content type—posts, testimonials, images, and more. Designed for speed, flexibility, and seamless integration with the WordPress block editor.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Easily create dynamic, accessible, and customizable carousels for any content ty
 
 | Requirement | Minimum      | Recommended |
 | ----------- | ------------ | ----------- |
-| WordPress   | 6.6+         | 6.9+        |
+| WordPress   | 6.6+         | 7.0+        |
 | PHP         | 8.2+         | 8.2+        |
 | Gutenberg   | Not required | —           |
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce07304be6cef4c520c42700f79bcaee",
+    "content-hash": "59a604a7dae48f9d42e8ddd64a862e7f",
     "packages": [],
     "packages-dev": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rt-carousel",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rt-carousel",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
         "@wordpress/babel-preset-default": "8.38.0",
         "@wordpress/block-editor": "^15.10.0",
@@ -4529,9 +4529,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4553,9 +4550,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4577,9 +4571,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4601,9 +4592,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4625,9 +4613,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4649,9 +4634,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7275,9 +7257,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7292,9 +7271,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7309,9 +7285,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7326,9 +7299,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7343,9 +7313,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7360,9 +7327,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7377,9 +7341,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7394,9 +7355,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23219,7 +23177,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rt-carousel",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Carousel block using Embla and WordPress Interactivity API",
   "author": "rtCamp",
   "private": true,

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: rtcamp, danish17, immasud, gagan0123, up1512001, mi5t4n, aviral89, vishal4669, imrraaj, aishwarryapande
 Tags: carousel, slider, block, interactivity-api, embla
 Requires at least: 6.6
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -84,6 +84,14 @@ rtCarousel is the successor to Carousel Kit. Simply install and activate rtCarou
 1. Carousel block in the editor with multiple slides
 
 == Changelog ==
+
+= 2.0.2 =
+* New: Carousel Counter block with an accessible current/total slide indicator
+* New: Slide template picker and starter templates for new carousel blocks
+* New: Terms Query support and Terms Query carousel pattern
+* Tweak: Confirm compatibility with WordPress 7.0
+* Tweak: Update JavaScript dependencies for upstream security and maintenance fixes
+
 
 = 2.0.1 =
 * New: Add a11y announcements for carousel slide changes

--- a/readme.txt
+++ b/readme.txt
@@ -14,8 +14,6 @@ A modular, high-performance carousel block for WordPress, powered by the Interac
 
 **rtCarousel** is a flexible, accessible carousel block for the WordPress block editor. Build dynamic carousels for posts, testimonials, images, and more—without writing code.
 
-Plugin page: https://wordpress.org/plugins/rt-carousel/
-
 = Features =
 
 * **Compound Block Architecture** – Mix and match any blocks inside the carousel

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,8 @@ A modular, high-performance carousel block for WordPress, powered by the Interac
 
 **rtCarousel** is a flexible, accessible carousel block for the WordPress block editor. Build dynamic carousels for posts, testimonials, images, and more—without writing code.
 
+Plugin page: https://wordpress.org/plugins/rt-carousel/
+
 = Features =
 
 * **Compound Block Architecture** – Mix and match any blocks inside the carousel

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === rtCarousel ===
-Contributors: rtcamp, danish17, immasud, gagan0123, up1512001, mi5t4n, aviral89, vishal4669, imrraaj, aishwarryapande
+Contributors: rtcamp, iamdanih17, immasud, gagan0123, up1512001, mi5t4n, aviral89, vishal4669, imrraaj, aishwarryapande
 Tags: carousel, slider, block, interactivity-api, embla
 Requires at least: 6.6
 Tested up to: 7.0

--- a/rt-carousel.php
+++ b/rt-carousel.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * License:     GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Version:     2.0.1
+ * Version:     2.0.2
  * Text Domain: rt-carousel
  *
  * @package rt-carousel


### PR DESCRIPTION
## Summary

 Prepare the `2.0.2` release of rtCarousel. This release updates plugin metadata, WordPress.org compatibility, changelog entries, and documentation for the latest changes merged into `develop`.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [x] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling


## What changed
   - Bumped plugin version to `2.0.2` across plugin header, `package.json`, `package-lock.json`, and `readme.txt`.
   - Updated WordPress compatibility to `Tested up to: 7.0`.
   - Added `2.0.2` release notes to `CHANGELOG.md` and `readme.txt`.
   - Included changelog entries for Carousel Counter, slide template picker, Terms Query support, dependency updates, and WP 7.0 compatibility.
   - Added WordPress.org plugin link and banner to `README.md`.

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
