### PR TITLE
chore: Fix coverage ignores, JS coverage, and release POT metadata

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 **/node_modules/**
 **/vendor/**
 **/build/**
+**/coverage/**

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ phpstan.neon
 # Test output
 /tests/_output/*
 !/tests/_output/.gitkeep
+coverage/
 
 # OS files
 [Tt]humbs.db

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,5 +1,6 @@
 ## Ignore build and dependency directories
 /build
+/coverage
 /node_modules
 /tests
 /vendor

--- a/languages/rt-carousel.pot
+++ b/languages/rt-carousel.pot
@@ -2,22 +2,22 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: rtCarousel 2.0.0\n"
+"Project-Id-Version: rtCarousel 2.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/rtCamp/rt-carousel/issues\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-15T21:07:27+00:00\n"
+"POT-Creation-Date: 2026-06-08T06:36:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.12.0\n"
+"X-Generator: WP-CLI 2.10.0\n"
 "X-Domain: rt-carousel\n"
 
 #. Plugin Name of the plugin
 #: rt-carousel.php
-#: inc/Plugin.php:97
-#: inc/Plugin.php:137
+#: inc/Plugin.php:118
+#: inc/Plugin.php:159
 msgid "rtCarousel"
 msgstr ""
 
@@ -45,11 +45,15 @@ msgstr ""
 msgid "rtCarousel: The Composer autoloader was not found. If you installed the plugin from the GitHub source code, make sure to run `composer install`."
 msgstr ""
 
-#: inc/Plugin.php:78
-msgid "The old \"Carousel Kit\" plugin has been deactivated. rtCarousel is its replacement."
+#: inc/Plugin.php:99
+msgid "The \"Carousel Kit\" plugin is still active. rtCarousel is its replacement — please deactivate Carousel Kit."
 msgstr ""
 
-#: inc/Plugin.php:138
+#: inc/Plugin.php:101
+msgid "Deactivate Carousel Kit"
+msgstr ""
+
+#: inc/Plugin.php:160
 msgid "Pre-configured carousel patterns for various use cases."
 msgstr ""
 
@@ -61,212 +65,295 @@ msgstr ""
 msgid "Next Slide"
 msgstr ""
 
+#. translators: 1: current slide number, 2: total slide count.
+#: build/blocks/carousel/counter/index.js:51
+msgid "Slide %1$d of %2$d"
+msgstr ""
+
+#: build/blocks/carousel/counter/index.js:122
+msgid "Carousel counter"
+msgstr ""
+
 #. translators: %d: slide number
 #: build/blocks/carousel/dots/index.js:2
 #: build/blocks/carousel/index.js:3
-#, js-format
+#: build/blocks/carousel/index.js:5
 msgid "Go to slide %d"
 msgstr ""
 
 #: build/blocks/carousel/index.js:1
+msgid "Text Slides"
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Slides starting with a paragraph you can replace or extend."
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Image Slides"
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Slides prefilled with an image block."
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Image + Heading + Text + CTA"
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Marketing slider with heading, paragraph, and button."
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Slide Heading"
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Slide description text…"
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Image + Caption"
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Image with supporting text below."
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Caption text…"
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Query Loop Slides"
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Dynamically generate slides from posts."
+msgstr ""
+
+#: build/blocks/carousel/index.js:1
+msgid "Back"
+msgstr ""
+
+#: build/blocks/carousel/index.js:3
 msgid "Carousel Settings"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Loop"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Enables infinite scrolling of slides."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Free Drag"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Enables momentum scrolling."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Alignment"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Start"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Center"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "End"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Contain Scroll"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Trim Snaps"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Keep Snaps"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "None"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Prevents excess scrolling at the beginning or end."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Scroll Auto"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Scrolls the number of slides currently visible in the viewport."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Slides to Scroll"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Direction"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Left to Right (LTR)"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Right to Left (RTL)"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Choose content direction. RTL is typically used for Arabic, Hebrew, and other right-to-left languages."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Orientation"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Horizontal"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Vertical"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Height"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Set a fixed height for vertical carousel (e.g., 400px)."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Autoplay Options"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Enable Autoplay"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Delay (ms)"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Stop on Interaction"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Stop autoplay when user interacts with carousel."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Stop on Mouse Enter"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Stop autoplay when mouse hovers over carousel."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "ARIA Label"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Provide a descriptive label for screen readers (e.g., 'Featured Products')."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Use this to allow only certain blocks in the slide. If empty, all blocks will be allowed."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Allowed Slide Blocks"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Layout"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Slide Gap (px)"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Carousel"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "How many slides would you like to start with?"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
+msgid "Choose a slide template:"
+msgstr ""
+
+#: build/blocks/carousel/index.js:3
 msgid "1 Slide"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Slides"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 msgid "Skip"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1
+#: build/blocks/carousel/index.js:3
 #: build/blocks/carousel/viewport/index.js:1
 msgid "Add Slide"
 msgstr ""
 
-#: build/blocks/carousel/index.js:3
+#. translators: {{currentSlide}}: current slide number, {{totalSlides}}: total slide count.
+#: build/blocks/carousel/index.js:7
+#: build/blocks/carousel/index.js:9
+msgid "Slide {{currentSlide}} of {{totalSlides}}"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
 msgid "Default (100%)"
 msgstr ""
 
-#: build/blocks/carousel/index.js:3
+#: build/blocks/carousel/index.js:9
 msgid "2 Columns (50%)"
 msgstr ""
 
-#: build/blocks/carousel/index.js:3
+#: build/blocks/carousel/index.js:9
 msgid "3 Columns (33%)"
 msgstr ""
 
-#: build/blocks/carousel/index.js:3
+#: build/blocks/carousel/index.js:9
 msgid "4 Columns (25%)"
 msgstr ""
 
 #: build/blocks/carousel/progress/index.js:1
 msgid "Carousel progress"
+msgstr ""
+
+#: build/blocks/carousel/viewport/index.js:1
+msgid "Add Query Loop"
+msgstr ""
+
+#: build/blocks/carousel/viewport/index.js:1
+msgid "Add Terms Query"
 msgstr ""
 
 #: build/blocks/carousel/viewport/index.js:1
@@ -295,6 +382,18 @@ msgstr ""
 #: src/blocks/carousel/controls/block.json
 msgctxt "block description"
 msgid "Navigation buttons for the carousel."
+msgstr ""
+
+#: build/blocks/carousel/counter/block.json
+#: src/blocks/carousel/counter/block.json
+msgctxt "block title"
+msgid "Carousel Counter"
+msgstr ""
+
+#: build/blocks/carousel/counter/block.json
+#: src/blocks/carousel/counter/block.json
+msgctxt "block description"
+msgid "Current slide counter for the carousel."
 msgstr ""
 
 #: build/blocks/carousel/dots/block.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2668,6 +2668,24 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
       "version": "4.1.1",
       "dev": true,
@@ -2677,6 +2695,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -2816,6 +2847,37 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -5561,6 +5623,39 @@
         "@opentelemetry/resources": "^1.30.1 || ^2.0.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.34.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sentry/node/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@sentry/opentelemetry": {
@@ -10450,14 +10545,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/bare-events": {
       "version": "2.8.2",
       "dev": true,
@@ -10661,17 +10748,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -11310,6 +11386,13 @@
     },
     "node_modules/computed-style": {
       "version": "0.1.4"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/configstore": {
       "version": "7.1.0",
@@ -13232,6 +13315,24 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "dev": true,
@@ -13249,6 +13350,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-jest": {
@@ -13453,6 +13567,37 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/eslint-plugin-playwright": {
       "version": "0.15.3",
       "dev": true,
@@ -13538,6 +13683,24 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
+    "node_modules/eslint-plugin-react/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",
       "dev": true,
@@ -13547,6 +13710,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -13603,6 +13779,24 @@
       "version": "2.0.1",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.2",
@@ -13668,6 +13862,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint/node_modules/p-locate": {
@@ -14679,6 +14886,37 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/global-directory": {
       "version": "4.0.1",
       "dev": true,
@@ -15309,6 +15547,37 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ignore-walk/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ignore-walk/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/ignore-walk/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/image-ssim": {
@@ -17636,6 +17905,24 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/markdownlint-cli/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdownlint-cli/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/markdownlint-cli/node_modules/commander": {
       "version": "9.0.0",
       "dev": true,
@@ -17661,6 +17948,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/minimatch": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/markdownlint-rule-helpers": {
@@ -17912,20 +18212,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/minimatch": {
-      "version": "10.2.4",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/minimist": {
       "version": "1.2.8",
@@ -22733,6 +23019,37 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/text-decoder": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "webpack-dev-server": ">=5.2.1",
-    "minimatch": ">=10.2.1",
     "serialize-javascript": ">=7.0.3"
   }
 }

--- a/src/blocks/carousel/counter/block.json
+++ b/src/blocks/carousel/counter/block.json
@@ -11,6 +11,7 @@
 	],
 	"description": "Current slide counter for the carousel.",
 	"textdomain": "rt-carousel",
+	"attributes": {},
 	"supports": {
 		"interactivity": true
 	},


### PR DESCRIPTION
## Summary

 - Ignore generated coverage/ output across Git, ESLint, and Stylelint.
 - Remove the minimatch override so npm run test:js:coverage works correctly with Istanbul/test-exclude.
 - Add empty attributes metadata for the carousel counter block to satisfy TypeScript block registration typing.
 - Refresh languages/rt-carousel.pot for the 2.0.2 release.
 
## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [x] Build/CI/tooling


## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [ ] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
