### PR TITLE
Update changelog to bump version 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.0.4](https://github.com/rtCamp/rt-carousel/compare/2.0.3...2.0.4) (2026-07-08)
+
+
+### Features
+
+* add Embla Auto Scroll plugin support with editor controls ([#152](https://github.com/rtCamp/rt-carousel/pull/152)) ([9e190c1](https://github.com/rtCamp/rt-carousel/commit/9e190c1))
+* add fade transition option ([#159](https://github.com/rtCamp/rt-carousel/pull/159)) ([12949f5](https://github.com/rtCamp/rt-carousel/commit/12949f5))
+
+
 ## [2.0.3](https://github.com/rtCamp/rt-carousel/compare/2.0.2...2.0.3) (2026-06-24)
 
 

--- a/languages/rt-carousel.pot
+++ b/languages/rt-carousel.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: rtCarousel 2.0.3\n"
+"Project-Id-Version: rtCarousel 2.0.4\n"
 "Report-Msgid-Bugs-To: https://github.com/rtCamp/rt-carousel/issues\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-25T06:24:07+00:00\n"
+"POT-Creation-Date: 2026-07-08T08:29:45+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.10.0\n"
+"X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: rt-carousel\n"
 
 #. Plugin Name of the plugin
@@ -57,311 +57,361 @@ msgstr ""
 msgid "Pre-configured carousel patterns for various use cases."
 msgstr ""
 
-#: build/blocks/carousel/controls/index.js:137
-#: build/blocks/carousel/controls/index.js:212
+#: build/blocks/carousel/controls/index.js:1
 msgid "Previous Slide"
 msgstr ""
 
-#: build/blocks/carousel/controls/index.js:147
-#: build/blocks/carousel/controls/index.js:219
+#: build/blocks/carousel/controls/index.js:1
 msgid "Next Slide"
 msgstr ""
 
 #. translators: 1: current slide number, 2: total slide count.
-#: build/blocks/carousel/counter/index.js:51
+#: build/blocks/carousel/counter/index.js:2
 msgid "Slide %1$d of %2$d"
 msgstr ""
 
-#: build/blocks/carousel/counter/index.js:122
+#: build/blocks/carousel/counter/index.js:2
 msgid "Carousel counter"
 msgstr ""
 
 #. translators: %d: slide number
-#: build/blocks/carousel/dots/index.js:123
-#: build/blocks/carousel/index.js:302
-#: build/blocks/carousel/index.js:1028
+#: build/blocks/carousel/dots/index.js:2
+#: build/blocks/carousel/index.js:3
+#: build/blocks/carousel/index.js:9
+#: build/blocks/carousel/index.js:11
 msgid "Go to slide %d"
 msgstr ""
 
-#: build/blocks/carousel/index.js:226
-msgid "Back"
-msgstr ""
-
-#: build/blocks/carousel/index.js:637
-msgid "Carousel Settings"
-msgstr ""
-
-#: build/blocks/carousel/index.js:639
-msgid "Loop"
-msgstr ""
-
-#: build/blocks/carousel/index.js:644
-msgid "Enables infinite scrolling of slides."
-msgstr ""
-
-#: build/blocks/carousel/index.js:646
-msgid "Free Drag"
-msgstr ""
-
-#: build/blocks/carousel/index.js:651
-msgid "Enables momentum scrolling."
-msgstr ""
-
-#: build/blocks/carousel/index.js:653
-msgid "Alignment"
-msgstr ""
-
-#: build/blocks/carousel/index.js:656
-msgid "Start"
-msgstr ""
-
-#: build/blocks/carousel/index.js:659
-msgid "Center"
-msgstr ""
-
-#: build/blocks/carousel/index.js:662
-msgid "End"
-msgstr ""
-
-#: build/blocks/carousel/index.js:669
-msgid "Contain Scroll"
-msgstr ""
-
-#: build/blocks/carousel/index.js:672
-msgid "Trim Snaps"
-msgstr ""
-
-#: build/blocks/carousel/index.js:675
-msgid "Keep Snaps"
-msgstr ""
-
-#: build/blocks/carousel/index.js:678
-msgid "None"
-msgstr ""
-
-#: build/blocks/carousel/index.js:684
-msgid "Prevents excess scrolling at the beginning or end."
-msgstr ""
-
-#: build/blocks/carousel/index.js:686
-msgid "Scroll Auto"
-msgstr ""
-
-#: build/blocks/carousel/index.js:691
-msgid "Scrolls the number of slides currently visible in the viewport."
-msgstr ""
-
-#: build/blocks/carousel/index.js:693
-msgid "Slides to Scroll"
-msgstr ""
-
-#: build/blocks/carousel/index.js:701
-msgid "Direction"
-msgstr ""
-
-#: build/blocks/carousel/index.js:704
-msgid "Left to Right (LTR)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:707
-msgid "Right to Left (RTL)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:713
-msgid "Choose content direction. RTL is typically used for Arabic, Hebrew, and other right-to-left languages."
-msgstr ""
-
-#: build/blocks/carousel/index.js:715
-msgid "Orientation"
-msgstr ""
-
-#: build/blocks/carousel/index.js:718
-msgid "Horizontal"
-msgstr ""
-
-#: build/blocks/carousel/index.js:721
-msgid "Vertical"
-msgstr ""
-
-#: build/blocks/carousel/index.js:728
-msgid "Height"
-msgstr ""
-
-#: build/blocks/carousel/index.js:733
-msgid "Set a fixed height for vertical carousel (e.g., 400px)."
-msgstr ""
-
-#: build/blocks/carousel/index.js:736
-msgid "Autoplay Options"
-msgstr ""
-
-#: build/blocks/carousel/index.js:739
-msgid "Enable Autoplay"
-msgstr ""
-
-#: build/blocks/carousel/index.js:746
-msgid "Delay (ms)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:755
-msgid "Stop on Interaction"
-msgstr ""
-
-#: build/blocks/carousel/index.js:760
-msgid "Stop autoplay when user interacts with carousel."
-msgstr ""
-
-#: build/blocks/carousel/index.js:762
-msgid "Stop on Mouse Enter"
-msgstr ""
-
-#: build/blocks/carousel/index.js:767
-msgid "Stop autoplay when mouse hovers over carousel."
-msgstr ""
-
-#: build/blocks/carousel/index.js:773
-msgid "ARIA Label"
-msgstr ""
-
-#: build/blocks/carousel/index.js:778
-msgid "Provide a descriptive label for screen readers (e.g., 'Featured Products')."
-msgstr ""
-
-#: build/blocks/carousel/index.js:781
-msgid "Use this to allow only certain blocks in the slide. If empty, all blocks will be allowed."
-msgstr ""
-
-#: build/blocks/carousel/index.js:784
-msgid "Allowed Slide Blocks"
-msgstr ""
-
-#: build/blocks/carousel/index.js:797
-msgid "Layout"
-msgstr ""
-
-#: build/blocks/carousel/index.js:799
-msgid "Slide Gap (px)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:819
-msgid "Carousel"
-msgstr ""
-
-#: build/blocks/carousel/index.js:820
-msgid "How many slides would you like to start with?"
-msgstr ""
-
-#: build/blocks/carousel/index.js:820
-msgid "Choose a slide template:"
-msgstr ""
-
-#: build/blocks/carousel/index.js:830
-msgid "1 Slide"
-msgstr ""
-
-#: build/blocks/carousel/index.js:830
-msgid "Slides"
-msgstr ""
-
-#: build/blocks/carousel/index.js:836
-msgid "Skip"
-msgstr ""
-
-#: build/blocks/carousel/index.js:855
-#: build/blocks/carousel/viewport/index.js:2093
-#: build/blocks/carousel/viewport/index.js:2244
-#: build/blocks/carousel/viewport/index.js:2254
-msgid "Add Slide"
-msgstr ""
-
-#: build/blocks/carousel/index.js:947
-msgid "Default (100%)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:951
-msgid "2 Columns (50%)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:954
-msgid "3 Columns (33%)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:957
-msgid "4 Columns (25%)"
-msgstr ""
-
-#. translators: {{currentSlide}}: current slide number, {{totalSlides}}: total slide count.
-#: build/blocks/carousel/index.js:1030
-#: build/blocks/carousel/index.js:1034
-msgid "Slide {{currentSlide}} of {{totalSlides}}"
-msgstr ""
-
-#: build/blocks/carousel/index.js:1123
+#: build/blocks/carousel/index.js:1
 msgid "Text Slides"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1124
+#: build/blocks/carousel/index.js:1
 msgid "Slides starting with a paragraph you can replace or extend."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1130
+#: build/blocks/carousel/index.js:1
 msgid "Image Slides"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1131
+#: build/blocks/carousel/index.js:1
 msgid "Slides prefilled with an image block."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1137
+#: build/blocks/carousel/index.js:1
 msgid "Image + Heading + Text + CTA"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1138
+#: build/blocks/carousel/index.js:1
 msgid "Marketing slider with heading, paragraph, and button."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1142
+#: build/blocks/carousel/index.js:1
 msgid "Slide Heading"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1144
+#: build/blocks/carousel/index.js:1
 msgid "Slide description text…"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1149
+#: build/blocks/carousel/index.js:1
 msgid "Image + Caption"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1150
+#: build/blocks/carousel/index.js:1
 msgid "Image with supporting text below."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1153
+#: build/blocks/carousel/index.js:1
 msgid "Caption text…"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1158
+#: build/blocks/carousel/index.js:1
 msgid "Query Loop Slides"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1159
+#: build/blocks/carousel/index.js:1
 msgid "Dynamically generate slides from posts."
 msgstr ""
 
-#: build/blocks/carousel/progress/index.js:95
-#: build/blocks/carousel/progress/index.js:161
+#: build/blocks/carousel/index.js:1
+msgid "Back"
+msgstr ""
+
+#. translators: {{currentSlide}}: current slide number, {{totalSlides}}: total slide count.
+#: build/blocks/carousel/index.js:5
+#: build/blocks/carousel/index.js:7
+#: build/blocks/carousel/index.js:13
+#: build/blocks/carousel/index.js:15
+msgid "Slide {{currentSlide}} of {{totalSlides}}"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Carousel Settings"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Transition"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Slide"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Fade"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Choose how slides transition: sliding horizontally or cross-fading."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Loop"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Loop is required for backward auto scroll."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Enables infinite scrolling of slides."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Free Drag"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Enables momentum scrolling."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Alignment"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Start"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Center"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "End"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Contain Scroll"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Trim Snaps"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Keep Snaps"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "None"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Prevents excess scrolling at the beginning or end."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Scroll Auto"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Scrolls the number of slides currently visible in the viewport."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Slides to Scroll"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Direction"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Left to Right (LTR)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Right to Left (RTL)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Choose content direction. RTL is typically used for Arabic, Hebrew, and other right-to-left languages."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Orientation"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Horizontal"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Vertical"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Height"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Set a fixed height for vertical carousel (e.g., 400px)."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Autoplay Options"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Enable Autoplay"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Delay (ms)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop on Interaction"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop autoplay when user interacts with carousel."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop on Mouse Enter"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop autoplay when mouse hovers over carousel."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Auto Scroll"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Enable Auto Scroll"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Speed"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Forward"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Backward"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Start Delay (ms)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop auto scroll when user interacts with carousel."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop auto scroll when mouse hovers over carousel."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "ARIA Label"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Provide a descriptive label for screen readers (e.g., 'Featured Products')."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Use this to allow only certain blocks in the slide. If empty, all blocks will be allowed."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Allowed Slide Blocks"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Layout"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Slide Gap (px)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Carousel"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "How many slides would you like to start with?"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Choose a slide template:"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "1 Slide"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Slides"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Skip"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+#: build/blocks/carousel/viewport/index.js:1
+msgid "Add Slide"
+msgstr ""
+
+#: build/blocks/carousel/index.js:15
+msgid "Default (100%)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:15
+msgid "2 Columns (50%)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:15
+msgid "3 Columns (33%)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:15
+msgid "4 Columns (25%)"
+msgstr ""
+
+#: build/blocks/carousel/progress/index.js:1
 msgid "Carousel progress"
 msgstr ""
 
-#: build/blocks/carousel/viewport/index.js:2097
+#: build/blocks/carousel/viewport/index.js:1
 msgid "Add Query Loop"
 msgstr ""
 
-#: build/blocks/carousel/viewport/index.js:2101
+#: build/blocks/carousel/viewport/index.js:1
 msgid "Add Terms Query"
 msgstr ""
 
-#: build/blocks/carousel/viewport/index.js:2249
+#: build/blocks/carousel/viewport/index.js:1
 msgid "Viewport Actions"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rt-carousel",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rt-carousel",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "@wordpress/babel-preset-default": "8.38.0",
         "@wordpress/block-editor": "^15.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rt-carousel",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Carousel block using Embla and WordPress Interactivity API",
   "author": "rtCamp",
   "private": true,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: carousel, slider, block, interactivity-api, embla
 Requires at least: 6.6
 Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: 2.0.3
+Stable tag: 2.0.4
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -84,6 +84,10 @@ rtCarousel is the successor to Carousel Kit. Simply install and activate rtCarou
 1. Carousel block in the editor with multiple slides
 
 == Changelog ==
+
+= 2.0.4 =
+* New: Embla Auto Scroll plugin support with editor controls
+* New: Fade transition option
 
 = 2.0.3 =
 * Tweak: Update plugin display name to a more descriptive title for discoverability.

--- a/rt-carousel.php
+++ b/rt-carousel.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * License:     GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Version:     2.0.3
+ * Version:     2.0.4
  * Text Domain: rt-carousel
  *
  * @package rt-carousel


### PR DESCRIPTION
## Summary

Prepare the 2.0.4 release of rtCarousel. This release updates plugin metadata, changelog entries, and documentation for the latest changes merged into develop.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [x] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

<!-- 'Closes' will automatically close the linked issue when this PR is merged. -->
<!-- 'Relates to' is for issues that are relevant but won't be closed by this PR. -->
Closes #<issue-number>
Relates to #<issue-number> (if applicable)

## What changed

- Bumped plugin version to 2.0.4 across plugin header, package.json, package-lock.json, and readme.txt.
- Added 2.0.4 release notes to CHANGELOG.md and readme.txt.
- Included changelog entries for Autoscroll feature and fade transition option

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [x] I have updated docs where needed
- [ ] I have checked for breaking changes
