### PR TITLE
Fix: Add logic to reset autoplay and autoscroll on carousel interaction

### DIFF
--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -303,6 +303,51 @@ describe( 'Carousel View Module', () => {
 				}
 			} );
 
+			it( 'should fall back to stop() when destroy is omitted and stopOnInteraction is true', () => {
+				const { wrapper, viewport, button } = createMockCarouselDOM();
+				const mockAutoplay = { stop: jest.fn(), reset: jest.fn() };
+				const mockAutoScroll = { stop: jest.fn(), reset: jest.fn() };
+				const mockEmbla = createMockEmblaInstance( {
+					plugins: jest.fn( () => ( {
+						autoplay: mockAutoplay,
+						autoScroll: mockAutoScroll,
+					} ) ),
+				} );
+
+				setEmblaOnViewport( viewport, mockEmbla );
+
+				const mockContext = createMockContext( {
+					autoplay: {
+						delay: 3000,
+						stopOnInteraction: true,
+						stopOnMouseEnter: true,
+					},
+					autoScroll: {
+						speed: 1,
+						direction: 'forward',
+						startDelay: 0,
+						stopOnInteraction: true,
+						stopOnMouseEnter: true,
+						stopOnFocusIn: true,
+					},
+				} );
+
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
+				document.body.appendChild( wrapper );
+
+				try {
+					storeConfig.actions.scrollPrev();
+
+					expect( mockAutoplay.stop ).toHaveBeenCalledTimes( 1 );
+					expect( mockAutoScroll.stop ).toHaveBeenCalledTimes( 1 );
+					expect( mockAutoplay.reset ).not.toHaveBeenCalled();
+					expect( mockAutoScroll.reset ).not.toHaveBeenCalled();
+				} finally {
+					document.body.removeChild( wrapper );
+				}
+			} );
+
 			it( 'should reset autoplay and autoscroll if stopOnInteraction is false', () => {
 				const { wrapper, viewport, button } = createMockCarouselDOM();
 				const mockAutoplay = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -257,6 +257,92 @@ describe( 'Carousel View Module', () => {
 
 				consoleSpy.mockRestore();
 			} );
+
+			it( 'should stop (destroy) autoplay and autoscroll if stopOnInteraction is true', () => {
+				const { wrapper, viewport, button } = createMockCarouselDOM();
+				const mockAutoplay = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockAutoScroll = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockEmbla = createMockEmblaInstance( {
+					plugins: jest.fn( () => ( {
+						autoplay: mockAutoplay,
+						autoScroll: mockAutoScroll,
+					} ) ),
+				} );
+
+				setEmblaOnViewport( viewport, mockEmbla );
+
+				const mockContext = createMockContext( {
+					autoplay: {
+						delay: 3000,
+						stopOnInteraction: true,
+						stopOnMouseEnter: true,
+					},
+					autoScroll: {
+						speed: 1,
+						direction: 'forward',
+						startDelay: 0,
+						stopOnInteraction: true,
+						stopOnMouseEnter: true,
+						stopOnFocusIn: true,
+					},
+				} );
+
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
+				document.body.appendChild( wrapper );
+
+				storeConfig.actions.scrollPrev();
+
+				expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
+				expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
+				expect( mockAutoplay.reset ).not.toHaveBeenCalled();
+				expect( mockAutoScroll.reset ).not.toHaveBeenCalled();
+
+				document.body.removeChild( wrapper );
+			} );
+
+			it( 'should reset autoplay and autoscroll if stopOnInteraction is false', () => {
+				const { wrapper, viewport, button } = createMockCarouselDOM();
+				const mockAutoplay = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockAutoScroll = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockEmbla = createMockEmblaInstance( {
+					plugins: jest.fn( () => ( {
+						autoplay: mockAutoplay,
+						autoScroll: mockAutoScroll,
+					} ) ),
+				} );
+
+				setEmblaOnViewport( viewport, mockEmbla );
+
+				const mockContext = createMockContext( {
+					autoplay: {
+						delay: 3000,
+						stopOnInteraction: false,
+						stopOnMouseEnter: true,
+					},
+					autoScroll: {
+						speed: 1,
+						direction: 'forward',
+						startDelay: 0,
+						stopOnInteraction: false,
+						stopOnMouseEnter: true,
+						stopOnFocusIn: true,
+					},
+				} );
+
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
+				document.body.appendChild( wrapper );
+
+				storeConfig.actions.scrollPrev();
+
+				expect( mockAutoplay.destroy ).not.toHaveBeenCalled();
+				expect( mockAutoScroll.destroy ).not.toHaveBeenCalled();
+				expect( mockAutoplay.reset ).toHaveBeenCalledTimes( 1 );
+				expect( mockAutoScroll.reset ).toHaveBeenCalledTimes( 1 );
+
+				document.body.removeChild( wrapper );
+			} );
 		} );
 
 		describe( 'scrollNext', () => {

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -435,6 +435,42 @@ describe( 'Carousel View Module', () => {
 					document.body.removeChild( wrapper );
 				}
 			} );
+
+			it( 'should not call stop, destroy, or reset on autoplay or autoscroll if context config is false', () => {
+				const { wrapper, viewport, button } = createMockCarouselDOM();
+				const mockAutoplay = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockAutoScroll = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockEmbla = createMockEmblaInstance( {
+					plugins: jest.fn( () => ( {
+						autoplay: mockAutoplay,
+						autoScroll: mockAutoScroll,
+					} ) ),
+				} );
+
+				setEmblaOnViewport( viewport, mockEmbla );
+
+				const mockContext = createMockContext( {
+					autoplay: false,
+					autoScroll: false,
+				} );
+
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
+				document.body.appendChild( wrapper );
+
+				try {
+					storeConfig.actions.scrollPrev();
+
+					expect( mockAutoplay.destroy ).not.toHaveBeenCalled();
+					expect( mockAutoplay.stop ).not.toHaveBeenCalled();
+					expect( mockAutoplay.reset ).not.toHaveBeenCalled();
+					expect( mockAutoScroll.destroy ).not.toHaveBeenCalled();
+					expect( mockAutoScroll.stop ).not.toHaveBeenCalled();
+					expect( mockAutoScroll.reset ).not.toHaveBeenCalled();
+				} finally {
+					document.body.removeChild( wrapper );
+				}
+			} );
 		} );
 
 		describe( 'scrollNext', () => {

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -343,6 +343,47 @@ describe( 'Carousel View Module', () => {
 
 				document.body.removeChild( wrapper );
 			} );
+
+			it( 'should stop (destroy) autoplay and autoscroll if stopOnInteraction is omitted/undefined (defaults to true)', () => {
+				const { wrapper, viewport, button } = createMockCarouselDOM();
+				const mockAutoplay = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockAutoScroll = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockEmbla = createMockEmblaInstance( {
+					plugins: jest.fn( () => ( {
+						autoplay: mockAutoplay,
+						autoScroll: mockAutoScroll,
+					} ) ),
+				} );
+
+				setEmblaOnViewport( viewport, mockEmbla );
+
+				const mockContext = createMockContext( {
+					autoplay: {
+						delay: 3000,
+						// stopOnInteraction omitted
+						stopOnMouseEnter: true,
+					} as unknown as CarouselContext[ 'autoplay' ],
+					autoScroll: {
+						speed: 1,
+						direction: 'forward',
+						startDelay: 0,
+						// stopOnInteraction omitted
+						stopOnMouseEnter: true,
+						stopOnFocusIn: true,
+					} as unknown as CarouselContext[ 'autoScroll' ],
+				} );
+
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
+				document.body.appendChild( wrapper );
+
+				storeConfig.actions.scrollPrev();
+
+				expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
+				expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
+
+				document.body.removeChild( wrapper );
+			} );
 		} );
 
 		describe( 'scrollNext', () => {
@@ -380,6 +421,47 @@ describe( 'Carousel View Module', () => {
 				);
 
 				consoleSpy.mockRestore();
+			} );
+
+			it( 'should stop autoplay and autoscroll if stopOnInteraction is true', () => {
+				const { wrapper, viewport, button } = createMockCarouselDOM();
+				const mockAutoplay = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockAutoScroll = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockEmbla = createMockEmblaInstance( {
+					plugins: jest.fn( () => ( {
+						autoplay: mockAutoplay,
+						autoScroll: mockAutoScroll,
+					} ) ),
+				} );
+
+				setEmblaOnViewport( viewport, mockEmbla );
+
+				const mockContext = createMockContext( {
+					autoplay: {
+						delay: 3000,
+						stopOnInteraction: true,
+						stopOnMouseEnter: true,
+					},
+					autoScroll: {
+						speed: 1,
+						direction: 'forward',
+						startDelay: 0,
+						stopOnInteraction: true,
+						stopOnMouseEnter: true,
+						stopOnFocusIn: true,
+					},
+				} );
+
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
+				document.body.appendChild( wrapper );
+
+				storeConfig.actions.scrollNext();
+
+				expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
+				expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
+
+				document.body.removeChild( wrapper );
 			} );
 		} );
 
@@ -439,6 +521,50 @@ describe( 'Carousel View Module', () => {
 				storeConfig.actions.onDotClick();
 
 				expect( mockEmbla.scrollTo ).toHaveBeenCalledWith( 0 );
+
+				document.body.removeChild( wrapper );
+			} );
+
+			it( 'should stop autoplay and autoscroll if stopOnInteraction is true', () => {
+				const { wrapper, viewport, button } = createMockCarouselDOM();
+				const mockAutoplay = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockAutoScroll = { stop: jest.fn(), destroy: jest.fn(), reset: jest.fn() };
+				const mockEmbla = createMockEmblaInstance( {
+					plugins: jest.fn( () => ( {
+						autoplay: mockAutoplay,
+						autoScroll: mockAutoScroll,
+					} ) ),
+				} );
+
+				setEmblaOnViewport( viewport, mockEmbla );
+
+				const mockContext = createMockContext( {
+					autoplay: {
+						delay: 3000,
+						stopOnInteraction: true,
+						stopOnMouseEnter: true,
+					},
+					autoScroll: {
+						speed: 1,
+						direction: 'forward',
+						startDelay: 0,
+						stopOnInteraction: true,
+						stopOnMouseEnter: true,
+						stopOnFocusIn: true,
+					},
+				} );
+				( mockContext as CarouselContext & { snap?: { index: number } } ).snap = {
+					index: 2,
+				};
+
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
+				document.body.appendChild( wrapper );
+
+				storeConfig.actions.onDotClick();
+
+				expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
+				expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
 
 				document.body.removeChild( wrapper );
 			} );

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -291,14 +291,16 @@ describe( 'Carousel View Module', () => {
 				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
 				document.body.appendChild( wrapper );
 
-				storeConfig.actions.scrollPrev();
+				try {
+					storeConfig.actions.scrollPrev();
 
-				expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
-				expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
-				expect( mockAutoplay.reset ).not.toHaveBeenCalled();
-				expect( mockAutoScroll.reset ).not.toHaveBeenCalled();
-
-				document.body.removeChild( wrapper );
+					expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
+					expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
+					expect( mockAutoplay.reset ).not.toHaveBeenCalled();
+					expect( mockAutoScroll.reset ).not.toHaveBeenCalled();
+				} finally {
+					document.body.removeChild( wrapper );
+				}
 			} );
 
 			it( 'should reset autoplay and autoscroll if stopOnInteraction is false', () => {
@@ -334,14 +336,16 @@ describe( 'Carousel View Module', () => {
 				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
 				document.body.appendChild( wrapper );
 
-				storeConfig.actions.scrollPrev();
+				try {
+					storeConfig.actions.scrollPrev();
 
-				expect( mockAutoplay.destroy ).not.toHaveBeenCalled();
-				expect( mockAutoScroll.destroy ).not.toHaveBeenCalled();
-				expect( mockAutoplay.reset ).toHaveBeenCalledTimes( 1 );
-				expect( mockAutoScroll.reset ).toHaveBeenCalledTimes( 1 );
-
-				document.body.removeChild( wrapper );
+					expect( mockAutoplay.destroy ).not.toHaveBeenCalled();
+					expect( mockAutoScroll.destroy ).not.toHaveBeenCalled();
+					expect( mockAutoplay.reset ).toHaveBeenCalledTimes( 1 );
+					expect( mockAutoScroll.reset ).toHaveBeenCalledTimes( 1 );
+				} finally {
+					document.body.removeChild( wrapper );
+				}
 			} );
 
 			it( 'should stop (destroy) autoplay and autoscroll if stopOnInteraction is omitted/undefined (defaults to true)', () => {
@@ -377,12 +381,14 @@ describe( 'Carousel View Module', () => {
 				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
 				document.body.appendChild( wrapper );
 
-				storeConfig.actions.scrollPrev();
+				try {
+					storeConfig.actions.scrollPrev();
 
-				expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
-				expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
-
-				document.body.removeChild( wrapper );
+					expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
+					expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
+				} finally {
+					document.body.removeChild( wrapper );
+				}
 			} );
 		} );
 
@@ -456,12 +462,14 @@ describe( 'Carousel View Module', () => {
 				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
 				document.body.appendChild( wrapper );
 
-				storeConfig.actions.scrollNext();
+				try {
+					storeConfig.actions.scrollNext();
 
-				expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
-				expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
-
-				document.body.removeChild( wrapper );
+					expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
+					expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
+				} finally {
+					document.body.removeChild( wrapper );
+				}
 			} );
 		} );
 
@@ -561,12 +569,14 @@ describe( 'Carousel View Module', () => {
 				( getElement as jest.Mock ).mockReturnValue( { ref: button } );
 				document.body.appendChild( wrapper );
 
-				storeConfig.actions.onDotClick();
+				try {
+					storeConfig.actions.onDotClick();
 
-				expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
-				expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
-
-				document.body.removeChild( wrapper );
+					expect( mockAutoplay.destroy ).toHaveBeenCalledTimes( 1 );
+					expect( mockAutoScroll.destroy ).toHaveBeenCalledTimes( 1 );
+				} finally {
+					document.body.removeChild( wrapper );
+				}
 			} );
 		} );
 	} );

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -125,6 +125,53 @@ const markForAnnouncement = (): void => {
 	getContext<CarouselContext>().shouldAnnounce = true;
 };
 
+const stopPluginsOnInteraction = (
+	embla: EmblaCarouselType,
+	context: CarouselContext,
+): void => {
+	if ( typeof embla.plugins !== 'function' ) {
+		return;
+	}
+	const plugins = embla.plugins() as {
+		autoplay?: { stop?: () => void; destroy?: () => void; reset?: () => void };
+		autoScroll?: { stop?: () => void; destroy?: () => void; reset?: () => void };
+	};
+	const autoplay = plugins.autoplay;
+	const autoScroll = plugins.autoScroll;
+
+	if ( autoplay && typeof autoplay.stop === 'function' ) {
+		if (
+			context.autoplay === true ||
+			( typeof context.autoplay === 'object' &&
+				context.autoplay.stopOnInteraction )
+		) {
+			if ( typeof autoplay.destroy === 'function' ) {
+				autoplay.destroy();
+			} else {
+				autoplay.stop();
+			}
+		} else if ( typeof autoplay.reset === 'function' ) {
+			autoplay.reset();
+		}
+	}
+
+	if ( autoScroll && typeof autoScroll.stop === 'function' ) {
+		if (
+			context.autoScroll === true ||
+			( typeof context.autoScroll === 'object' &&
+				context.autoScroll.stopOnInteraction )
+		) {
+			if ( typeof autoScroll.destroy === 'function' ) {
+				autoScroll.destroy();
+			} else {
+				autoScroll.stop();
+			}
+		} else if ( typeof autoScroll.reset === 'function' ) {
+			autoScroll.reset();
+		}
+	}
+};
+
 store( 'rt-carousel/carousel', {
 	state: {
 		get canScrollPrev() {
@@ -141,6 +188,9 @@ store( 'rt-carousel/carousel', {
 			const element = getElementRef( getElement() );
 			const embla = getEmblaFromElement( element );
 			if ( embla ) {
+				const context = getContext<CarouselContext>();
+				stopPluginsOnInteraction( embla, context );
+
 				if ( embla.canScrollPrev() ) {
 					markForAnnouncement();
 				}
@@ -154,6 +204,9 @@ store( 'rt-carousel/carousel', {
 			const element = getElementRef( getElement() );
 			const embla = getEmblaFromElement( element );
 			if ( embla ) {
+				const context = getContext<CarouselContext>();
+				stopPluginsOnInteraction( embla, context );
+
 				if ( embla.canScrollNext() ) {
 					markForAnnouncement();
 				}
@@ -173,6 +226,8 @@ store( 'rt-carousel/carousel', {
 				const element = getElementRef( getElement() );
 				const embla = getEmblaFromElement( element );
 				if ( embla ) {
+					stopPluginsOnInteraction( embla, context );
+
 					if ( snap.index !== context.selectedIndex ) {
 						markForAnnouncement();
 					}

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -145,7 +145,10 @@ const stopPluginsOnInteraction = (
 	const autoplay = plugins.autoplay;
 	const autoScroll = plugins.autoScroll;
 
-	if ( autoplay ) {
+	const isAutoplayEnabled =
+		context.autoplay === true ||
+		( typeof context.autoplay === 'object' && context.autoplay !== null );
+	if ( autoplay && isAutoplayEnabled ) {
 		const shouldStop =
 			context.autoplay === true ||
 			( typeof context.autoplay === 'object' &&
@@ -162,7 +165,10 @@ const stopPluginsOnInteraction = (
 		}
 	}
 
-	if ( autoScroll ) {
+	const isAutoScrollEnabled =
+		context.autoScroll === true ||
+		( typeof context.autoScroll === 'object' && context.autoScroll !== null );
+	if ( autoScroll && isAutoScrollEnabled ) {
 		const shouldStop =
 			context.autoScroll === true ||
 			( typeof context.autoScroll === 'object' &&

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -145,15 +145,16 @@ const stopPluginsOnInteraction = (
 	const autoplay = plugins.autoplay;
 	const autoScroll = plugins.autoScroll;
 
-	if ( autoplay && typeof autoplay.stop === 'function' ) {
-		if (
+	if ( autoplay ) {
+		const shouldStop =
 			context.autoplay === true ||
 			( typeof context.autoplay === 'object' &&
-				context.autoplay.stopOnInteraction !== false )
-		) {
+				context.autoplay.stopOnInteraction !== false );
+
+		if ( shouldStop ) {
 			if ( typeof autoplay.destroy === 'function' ) {
 				autoplay.destroy();
-			} else {
+			} else if ( typeof autoplay.stop === 'function' ) {
 				autoplay.stop();
 			}
 		} else if ( typeof autoplay.reset === 'function' ) {
@@ -161,15 +162,16 @@ const stopPluginsOnInteraction = (
 		}
 	}
 
-	if ( autoScroll && typeof autoScroll.stop === 'function' ) {
-		if (
+	if ( autoScroll ) {
+		const shouldStop =
 			context.autoScroll === true ||
 			( typeof context.autoScroll === 'object' &&
-				context.autoScroll.stopOnInteraction !== false )
-		) {
+				context.autoScroll.stopOnInteraction !== false );
+
+		if ( shouldStop ) {
 			if ( typeof autoScroll.destroy === 'function' ) {
 				autoScroll.destroy();
-			} else {
+			} else if ( typeof autoScroll.stop === 'function' ) {
 				autoScroll.stop();
 			}
 		} else if ( typeof autoScroll.reset === 'function' ) {

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -125,6 +125,12 @@ const markForAnnouncement = (): void => {
 	getContext<CarouselContext>().shouldAnnounce = true;
 };
 
+type StoppablePlugin = {
+	stop?: () => void;
+	destroy?: () => void;
+	reset?: () => void;
+};
+
 const stopPluginsOnInteraction = (
 	embla: EmblaCarouselType,
 	context: CarouselContext,
@@ -133,8 +139,8 @@ const stopPluginsOnInteraction = (
 		return;
 	}
 	const plugins = embla.plugins() as {
-		autoplay?: { stop?: () => void; destroy?: () => void; reset?: () => void };
-		autoScroll?: { stop?: () => void; destroy?: () => void; reset?: () => void };
+		autoplay?: StoppablePlugin;
+		autoScroll?: StoppablePlugin;
 	};
 	const autoplay = plugins.autoplay;
 	const autoScroll = plugins.autoScroll;
@@ -143,7 +149,7 @@ const stopPluginsOnInteraction = (
 		if (
 			context.autoplay === true ||
 			( typeof context.autoplay === 'object' &&
-				context.autoplay.stopOnInteraction )
+				context.autoplay.stopOnInteraction !== false )
 		) {
 			if ( typeof autoplay.destroy === 'function' ) {
 				autoplay.destroy();
@@ -159,7 +165,7 @@ const stopPluginsOnInteraction = (
 		if (
 			context.autoScroll === true ||
 			( typeof context.autoScroll === 'object' &&
-				context.autoScroll.stopOnInteraction )
+				context.autoScroll.stopOnInteraction !== false )
 		) {
 			if ( typeof autoScroll.destroy === 'function' ) {
 				autoScroll.destroy();


### PR DESCRIPTION

## Summary

This pull request enhances the carousel's behavior by improving how autoplay and autoscroll plugins respond to user interactions, and adds comprehensive tests to verify these behaviors. The main focus is to ensure that, depending on configuration, the carousel either stops or resets these plugins when users interact with navigation controls.

**Carousel plugin interaction handling:**

* Added the `stopPluginsOnInteraction` utility to centralize logic for stopping or resetting the `autoplay` and `autoScroll` plugins based on the `stopOnInteraction` configuration in the carousel context.
* Updated the carousel's `scrollPrev`, `scrollNext`, and `scrollToSnap` actions to invoke `stopPluginsOnInteraction` before scrolling, ensuring consistent plugin behavior on user interaction. [[1]](diffhunk://#diff-dd819e3dcf8b796c3b2861b7a0b29181bca2cde9c26272ab317f6f500eafff90R191-R193) [[2]](diffhunk://#diff-dd819e3dcf8b796c3b2861b7a0b29181bca2cde9c26272ab317f6f500eafff90R207-R209) [[3]](diffhunk://#diff-dd819e3dcf8b796c3b2861b7a0b29181bca2cde9c26272ab317f6f500eafff90R229-R230)

**Testing improvements:**

* Added new tests to verify that `autoplay` and `autoScroll` plugins are properly stopped (destroyed) or reset when the user interacts with carousel controls, depending on the `stopOnInteraction` setting.
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

<!-- 'Closes' will automatically close the linked issue when this PR is merged. -->
<!-- 'Relates to' is for issues that are relevant but won't be closed by this PR. -->
Closes https://github.com/rtCamp/rt-carousel/issues/163

## What changed

- When both Stop on `Interaction and Stop` and `on Mouse Hover` are enabled the User is now able to interact with Next and previous buttons and carousel dots and stop autoscroll
- When Just `Stop on Interaction` is enabled, If user click on Next previous button or interact with slides it stops autoscroll
- When Just `on Mouse Hover` is enabled and if user hover on slides it stops the slide and On mouse out it continue with autoscroll effect.

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
