### PR TITLE
feat(carousel): improve Auto Scroll UX and enforce compatible transition settings

### DIFF
--- a/src/blocks/carousel/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/__tests__/edit.test.tsx
@@ -257,6 +257,7 @@ describe( 'Carousel Edit setup flow', () => {
 		expect( selectLabels ).not.toContain( 'Contain Scroll' );
 		expect( toggleLabels ).not.toContain( 'Free Drag' );
 		expect( toggleLabels ).not.toContain( 'Scroll Auto' );
+		expect( toggleLabels ).not.toContain( 'Enable Auto Scroll' );
 		expect( ( RangeControl as unknown as jest.Mock ).mock.calls.some(
 			( [ props ] ) => props.label === 'Slides to Scroll',
 		) ).toBe( false );
@@ -282,6 +283,7 @@ describe( 'Carousel Edit setup flow', () => {
 		expect( selectLabels ).toContain( 'Contain Scroll' );
 		expect( toggleLabels ).toContain( 'Free Drag' );
 		expect( toggleLabels ).toContain( 'Scroll Auto' );
+		expect( toggleLabels ).toContain( 'Enable Auto Scroll' );
 	} );
 
 	it( 'calls setAttributes with the selected transition', () => {
@@ -300,6 +302,6 @@ describe( 'Carousel Edit setup flow', () => {
 
 		transitionCall[ 0 ].onChange( 'fade' );
 
-		expect( setAttributes ).toHaveBeenCalledWith( { transition: 'fade' } );
+		expect( setAttributes ).toHaveBeenCalledWith( { transition: 'fade', autoScroll: false } );
 	} );
 } );

--- a/src/blocks/carousel/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/__tests__/edit.test.tsx
@@ -257,7 +257,7 @@ describe( 'Carousel Edit setup flow', () => {
 		expect( selectLabels ).not.toContain( 'Contain Scroll' );
 		expect( toggleLabels ).not.toContain( 'Free Drag' );
 		expect( toggleLabels ).not.toContain( 'Scroll Auto' );
-		expect( toggleLabels ).not.toContain( 'Enable Auto Scroll' );
+		expect( toggleLabels ).toContain( 'Enable Auto Scroll' );
 		expect( ( RangeControl as unknown as jest.Mock ).mock.calls.some(
 			( [ props ] ) => props.label === 'Slides to Scroll',
 		) ).toBe( false );
@@ -302,6 +302,45 @@ describe( 'Carousel Edit setup flow', () => {
 
 		transitionCall[ 0 ].onChange( 'fade' );
 
-		expect( setAttributes ).toHaveBeenCalledWith( { transition: 'fade', autoScroll: false } );
+		expect( setAttributes ).toHaveBeenCalledWith( { transition: 'fade' } );
+	} );
+
+	it( 'disables the transition dropdown with notice when autoScroll is enabled', () => {
+		render(
+			<Edit
+				attributes={ { ...createAttributes(), autoScroll: true } }
+				setAttributes={ jest.fn() }
+				clientId="client-transition-disabled"
+			/>,
+		);
+
+		const transitionCall = ( SelectControl as unknown as jest.Mock ).mock.calls.find(
+			( [ props ] ) => props.label === 'Transition',
+		);
+
+		expect( transitionCall[ 0 ].disabled ).toBe( true );
+		expect( transitionCall[ 0 ].help ).toBe( 'Auto Scroll does not support transitions.' );
+	} );
+
+	it( 'switches transition to slide when autoScroll is enabled', () => {
+		const setAttributes = jest.fn();
+		render(
+			<Edit
+				attributes={ { ...createAttributes(), transition: 'fade' } }
+				setAttributes={ setAttributes }
+				clientId="client-autoscroll-toggle"
+			/>,
+		);
+
+		const autoScrollToggle = ( ToggleControl as unknown as jest.Mock ).mock.calls.find(
+			( [ props ] ) => props.label === 'Enable Auto Scroll',
+		);
+
+		autoScrollToggle[ 0 ].onChange( true );
+
+		expect( setAttributes ).toHaveBeenCalledWith( expect.objectContaining( {
+			autoScroll: true,
+			transition: 'slide',
+		} ) );
 	} );
 } );

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -175,6 +175,29 @@ describe( 'Carousel View Module', () => {
 
 				expect( result ).toBe( false );
 			} );
+
+			it( 'should return true when autoScroll is enabled', () => {
+				const mockContext = createMockContext( {
+					canScrollPrev: false,
+					autoScroll: {
+						speed: 2,
+						direction: 'forward',
+						startDelay: 1000,
+						stopOnInteraction: true,
+						stopOnMouseEnter: false,
+						stopOnFocusIn: true,
+					},
+				} );
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+
+				const result =
+					Object.getOwnPropertyDescriptor(
+						storeConfig.state,
+						'canScrollPrev',
+					)?.get?.() ?? false;
+
+				expect( result ).toBe( true );
+			} );
 		} );
 
 		describe( 'canScrollNext', () => {
@@ -202,6 +225,29 @@ describe( 'Carousel View Module', () => {
 					)?.get?.() ?? true;
 
 				expect( result ).toBe( false );
+			} );
+
+			it( 'should return true when autoScroll is enabled', () => {
+				const mockContext = createMockContext( {
+					canScrollNext: false,
+					autoScroll: {
+						speed: 2,
+						direction: 'forward',
+						startDelay: 1000,
+						stopOnInteraction: true,
+						stopOnMouseEnter: false,
+						stopOnFocusIn: true,
+					},
+				} );
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+
+				const result =
+					Object.getOwnPropertyDescriptor(
+						storeConfig.state,
+						'canScrollNext',
+					)?.get?.() ?? false;
+
+				expect( result ).toBe( true );
 			} );
 		} );
 	} );
@@ -915,7 +961,7 @@ describe( 'Carousel View Module', () => {
 				}
 			} );
 
-			it( 'does not include the AutoScroll plugin when transition is fade', () => {
+			it( 'includes the AutoScroll plugin when transition is fade', () => {
 				const mockContext = createMockContext( {
 					transition: 'fade',
 					autoScroll: {
@@ -924,6 +970,7 @@ describe( 'Carousel View Module', () => {
 						startDelay: 1000,
 						stopOnInteraction: true,
 						stopOnMouseEnter: false,
+						stopOnFocusIn: true,
 					},
 				} );
 				const { wrapper, viewport } = createMockCarouselDOM();
@@ -957,9 +1004,7 @@ describe( 'Carousel View Module', () => {
 					const lastCall = ( EmblaCarousel as unknown as jest.Mock ).mock.calls.at( -1 );
 					expect( lastCall?.[ 2 ] ).toContainEqual( ( Fade as unknown as jest.Mock ).mock.results.at( -1 )?.value );
 					const autoScrollMockResult = ( AutoScroll as unknown as jest.Mock ).mock.results.at( -1 )?.value;
-					if ( autoScrollMockResult ) {
-						expect( lastCall?.[ 2 ] ).not.toContainEqual( autoScrollMockResult );
-					}
+					expect( lastCall?.[ 2 ] ).toContainEqual( autoScrollMockResult );
 				} finally {
 					( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver =
 						originalIntersectionObserver;

--- a/src/blocks/carousel/__tests__/view.test.ts
+++ b/src/blocks/carousel/__tests__/view.test.ts
@@ -16,6 +16,7 @@ import { store, getContext, getElement } from '@wordpress/interactivity';
 
 import EmblaCarousel, { type EmblaCarouselType } from 'embla-carousel';
 import Fade from 'embla-carousel-fade';
+import AutoScroll from 'embla-carousel-auto-scroll';
 
 // Symbol key used by the view.ts for Embla instances
 const EMBLA_KEY = Symbol.for( 'rt-carousel.carousel' );
@@ -908,6 +909,57 @@ describe( 'Carousel View Module', () => {
 
 					const lastCall = ( EmblaCarousel as unknown as jest.Mock ).mock.calls.at( -1 );
 					expect( lastCall?.[ 2 ] ).toEqual( [] );
+				} finally {
+					( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver =
+						originalIntersectionObserver;
+				}
+			} );
+
+			it( 'does not include the AutoScroll plugin when transition is fade', () => {
+				const mockContext = createMockContext( {
+					transition: 'fade',
+					autoScroll: {
+						speed: 2,
+						direction: 'forward',
+						startDelay: 1000,
+						stopOnInteraction: true,
+						stopOnMouseEnter: false,
+					},
+				} );
+				const { wrapper, viewport } = createMockCarouselDOM();
+				const originalIntersectionObserver = window.IntersectionObserver;
+
+				viewport.getBoundingClientRect = jest.fn( () => ( {
+					width: 100,
+					height: 0,
+					top: 0,
+					right: 0,
+					bottom: 0,
+					left: 0,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) );
+
+				( getContext as jest.Mock ).mockReturnValue( mockContext );
+				( getElement as jest.Mock ).mockReturnValue( { ref: wrapper } );
+				( EmblaCarousel as unknown as jest.Mock ).mockReturnValue(
+					createMockEmblaInstance( {
+						scrollProgress: jest.fn( () => 0 ),
+						slideNodes: jest.fn( () => [] ),
+					} ),
+				);
+				delete ( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver;
+
+				try {
+					storeConfig.callbacks.initCarousel();
+
+					const lastCall = ( EmblaCarousel as unknown as jest.Mock ).mock.calls.at( -1 );
+					expect( lastCall?.[ 2 ] ).toContainEqual( ( Fade as unknown as jest.Mock ).mock.results.at( -1 )?.value );
+					const autoScrollMockResult = ( AutoScroll as unknown as jest.Mock ).mock.results.at( -1 )?.value;
+					if ( autoScrollMockResult ) {
+						expect( lastCall?.[ 2 ] ).not.toContainEqual( autoScrollMockResult );
+					}
 				} finally {
 					( window as Window & { IntersectionObserver?: typeof IntersectionObserver } ).IntersectionObserver =
 						originalIntersectionObserver;

--- a/src/blocks/carousel/controls/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/controls/__tests__/edit.test.tsx
@@ -41,7 +41,7 @@ describe( 'Carousel Controls Edit', () => {
 				} }
 			>
 				<Edit />
-			</EditorCarouselContext.Provider>
+			</EditorCarouselContext.Provider>,
 		);
 
 		const prevBtn = screen.getByRole( 'button', { name: 'Previous Slide' } );
@@ -73,7 +73,7 @@ describe( 'Carousel Controls Edit', () => {
 				} }
 			>
 				<Edit />
-			</EditorCarouselContext.Provider>
+			</EditorCarouselContext.Provider>,
 		);
 
 		const prevBtn = screen.getByRole( 'button', { name: 'Previous Slide' } );

--- a/src/blocks/carousel/controls/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/controls/__tests__/edit.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the carousel controls edit component.
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import Edit from '../edit';
+import { EditorCarouselContext } from '../../editor-context';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: jest.fn( ( props = {} ) => ( {
+		...props,
+		ref: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	useMergeRefs: jest.fn( () => jest.fn() ),
+} ) );
+
+describe( 'Carousel Controls Edit', () => {
+	it( 'disables buttons when autoScroll is false and canScrollPrev/canScrollNext are false', () => {
+		render(
+			<EditorCarouselContext.Provider
+				value={ {
+					emblaApi: undefined,
+					setEmblaApi: jest.fn(),
+					canScrollPrev: false,
+					canScrollNext: false,
+					setCanScrollPrev: jest.fn(),
+					setCanScrollNext: jest.fn(),
+					scrollProgress: 0,
+					setScrollProgress: jest.fn(),
+					selectedIndex: 0,
+					setSelectedIndex: jest.fn(),
+					scrollSnaps: [],
+					slideCount: 2,
+					carouselOptions: {
+						autoScroll: false,
+					},
+				} }
+			>
+				<Edit />
+			</EditorCarouselContext.Provider>
+		);
+
+		const prevBtn = screen.getByRole( 'button', { name: 'Previous Slide' } );
+		const nextBtn = screen.getByRole( 'button', { name: 'Next Slide' } );
+
+		expect( prevBtn ).toBeDisabled();
+		expect( nextBtn ).toBeDisabled();
+	} );
+
+	it( 'keeps prev/next buttons enabled when autoScroll is true even if canScrollPrev/canScrollNext are false', () => {
+		render(
+			<EditorCarouselContext.Provider
+				value={ {
+					emblaApi: undefined,
+					setEmblaApi: jest.fn(),
+					canScrollPrev: false,
+					canScrollNext: false,
+					setCanScrollPrev: jest.fn(),
+					setCanScrollNext: jest.fn(),
+					scrollProgress: 0,
+					setScrollProgress: jest.fn(),
+					selectedIndex: 0,
+					setSelectedIndex: jest.fn(),
+					scrollSnaps: [],
+					slideCount: 2,
+					carouselOptions: {
+						autoScroll: true,
+					},
+				} }
+			>
+				<Edit />
+			</EditorCarouselContext.Provider>
+		);
+
+		const prevBtn = screen.getByRole( 'button', { name: 'Previous Slide' } );
+		const nextBtn = screen.getByRole( 'button', { name: 'Next Slide' } );
+
+		expect( prevBtn ).not.toBeDisabled();
+		expect( nextBtn ).not.toBeDisabled();
+	} );
+} );

--- a/src/blocks/carousel/controls/edit.tsx
+++ b/src/blocks/carousel/controls/edit.tsx
@@ -13,6 +13,7 @@ export default function Edit() {
 		emblaApi: contextApi,
 		canScrollPrev,
 		canScrollNext,
+		carouselOptions,
 	} = useContext( EditorCarouselContext );
 	const ref = useRef<HTMLDivElement>( null );
 
@@ -58,7 +59,7 @@ export default function Edit() {
 					handleScroll( 'prev' );
 				} }
 				type="button"
-				disabled={ ! canScrollPrev }
+				disabled={ ! carouselOptions?.autoScroll && ! canScrollPrev }
 				aria-label={ __( 'Previous Slide', 'rt-carousel' ) }
 			>
 				<PreviousIcon />
@@ -70,7 +71,7 @@ export default function Edit() {
 					handleScroll( 'next' );
 				} }
 				type="button"
-				disabled={ ! canScrollNext }
+				disabled={ ! carouselOptions?.autoScroll && ! canScrollNext }
 				aria-label={ __( 'Next Slide', 'rt-carousel' ) }
 			>
 				<NextIcon />

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -326,9 +326,16 @@ export default function Edit( {
 							{ label: __( 'Slide', 'rt-carousel' ), value: 'slide' },
 							{ label: __( 'Fade', 'rt-carousel' ), value: 'fade' },
 						] }
-						onChange={ ( value ) =>
-							setAttributes( { transition: value as CarouselAttributes[ 'transition' ] } )
-						}
+						onChange={ ( value ) => {
+							const nextTransition = value as CarouselAttributes[ 'transition' ];
+							const nextAttributes: Partial< CarouselAttributes > = {
+								transition: nextTransition,
+							};
+							if ( nextTransition === 'fade' ) {
+								nextAttributes.autoScroll = false;
+							}
+							setAttributes( nextAttributes );
+						} }
 						help={ __(
 							'Choose how slides transition: sliding horizontally or cross-fading.',
 							'rt-carousel',
@@ -496,71 +503,73 @@ export default function Edit( {
 						</>
 					) }
 				</PanelBody>
-				<PanelBody
-					title={ __( 'Auto Scroll', 'rt-carousel' ) }
-					initialOpen={ false }
-				>
-					<ToggleControl
-						label={ __( 'Enable Auto Scroll', 'rt-carousel' ) }
-						checked={ autoScroll }
-						onChange={ ( value ) => setAttributes( {
-							autoScroll: value,
-							autoplay: value ? false : autoplay,
-							loop: ( value && autoScrollDirection === 'backward' ) ? true : loop,
-						} ) }
-					/>
-					{ autoScroll && ( <>
-						<RangeControl
-							label={ __( 'Speed', 'rt-carousel' ) }
-							value={ autoScrollSpeed }
-							onChange={ ( value ) =>
-								setAttributes( { autoScrollSpeed: value ?? 2 } )
-							}
-							min={ 1 }
-							max={ 10 }
-						/>
-						<SelectControl
-							label={ __( 'Direction', 'rt-carousel' ) }
-							value={ autoScrollDirection }
-							options={ [
-								{ label: __( 'Forward', 'rt-carousel' ), value: 'forward' },
-								{ label: __( 'Backward', 'rt-carousel' ), value: 'backward' },
-							] }
-							onChange={ ( value ) =>
-								setAttributes( {
-									autoScrollDirection: value as CarouselAttributes['autoScrollDirection'],
-									loop: value === 'backward' ? true : loop,
-								} )
-							}
-						/>
-						<RangeControl
-							label={ __( 'Start Delay (ms)', 'rt-carousel' ) }
-							value={ autoScrollStartDelay }
-							onChange={ ( value ) =>
-								setAttributes( { autoScrollStartDelay: value ?? 1000 } )
-							}
-							min={ 0 }
-							max={ 10000 }
-							step={ 100 }
-						/>
+				{ transition !== 'fade' && (
+					<PanelBody
+						title={ __( 'Auto Scroll', 'rt-carousel' ) }
+						initialOpen={ false }
+					>
 						<ToggleControl
-							label={ __( 'Stop on Interaction', 'rt-carousel' ) }
-							checked={ autoScrollStopOnInteraction }
-							onChange={ ( value ) =>
-								setAttributes( { autoScrollStopOnInteraction: value } )
-							}
-							help={ __( 'Stop auto scroll when user interacts with carousel.', 'rt-carousel' ) }
+							label={ __( 'Enable Auto Scroll', 'rt-carousel' ) }
+							checked={ autoScroll }
+							onChange={ ( value ) => setAttributes( {
+								autoScroll: value,
+								autoplay: value ? false : autoplay,
+								loop: ( value && autoScrollDirection === 'backward' ) ? true : loop,
+							} ) }
 						/>
-						<ToggleControl
-							label={ __( 'Stop on Mouse Enter', 'rt-carousel' ) }
-							checked={ autoScrollStopOnMouseEnter }
-							onChange={ ( value ) =>
-								setAttributes( { autoScrollStopOnMouseEnter: value } )
-							}
-							help={ __( 'Stop auto scroll when mouse hovers over carousel.', 'rt-carousel' ) }
-						/>
-					</> ) }
-				</PanelBody>
+						{ autoScroll && ( <>
+							<RangeControl
+								label={ __( 'Speed', 'rt-carousel' ) }
+								value={ autoScrollSpeed }
+								onChange={ ( value ) =>
+									setAttributes( { autoScrollSpeed: value ?? 2 } )
+								}
+								min={ 1 }
+								max={ 10 }
+							/>
+							<SelectControl
+								label={ __( 'Direction', 'rt-carousel' ) }
+								value={ autoScrollDirection }
+								options={ [
+									{ label: __( 'Forward', 'rt-carousel' ), value: 'forward' },
+									{ label: __( 'Backward', 'rt-carousel' ), value: 'backward' },
+								] }
+								onChange={ ( value ) =>
+									setAttributes( {
+										autoScrollDirection: value as CarouselAttributes['autoScrollDirection'],
+										loop: value === 'backward' ? true : loop,
+									} )
+								}
+							/>
+							<RangeControl
+								label={ __( 'Start Delay (ms)', 'rt-carousel' ) }
+								value={ autoScrollStartDelay }
+								onChange={ ( value ) =>
+									setAttributes( { autoScrollStartDelay: value ?? 1000 } )
+								}
+								min={ 0 }
+								max={ 10000 }
+								step={ 100 }
+							/>
+							<ToggleControl
+								label={ __( 'Stop on Interaction', 'rt-carousel' ) }
+								checked={ autoScrollStopOnInteraction }
+								onChange={ ( value ) =>
+									setAttributes( { autoScrollStopOnInteraction: value } )
+								}
+								help={ __( 'Stop auto scroll when user interacts with carousel.', 'rt-carousel' ) }
+							/>
+							<ToggleControl
+								label={ __( 'Stop on Mouse Enter', 'rt-carousel' ) }
+								checked={ autoScrollStopOnMouseEnter }
+								onChange={ ( value ) =>
+									setAttributes( { autoScrollStopOnMouseEnter: value } )
+								}
+								help={ __( 'Stop auto scroll when mouse hovers over carousel.', 'rt-carousel' ) }
+							/>
+						</> ) }
+					</PanelBody>
+				) }
 			</InspectorControls>
 			<InspectorAdvancedControls>
 				<TextControl

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -195,9 +195,10 @@ export default function Edit( {
 			axis,
 			height,
 			slidesToScroll: slidesToScroll === 'auto' ? 'auto' : parseInt( slidesToScroll, 10 ),
+			autoScroll,
 			...( useTabs ? { duration: 0 } : {} ),
 		} ),
-		[ transition, loop, dragFree, carouselAlign, containScroll, direction, axis, height, slidesToScroll, useTabs ],
+		[ transition, loop, dragFree, carouselAlign, containScroll, direction, axis, height, slidesToScroll, autoScroll, useTabs ],
 	);
 
 	const contextValue = useMemo(

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -217,6 +217,7 @@ export default function Edit( {
 			slideCount,
 			carouselOptions,
 			useTabs,
+			autoScroll,
 		} ),
 		[
 			emblaApi,
@@ -228,6 +229,7 @@ export default function Edit( {
 			slideCount,
 			carouselOptions,
 			useTabs,
+			autoScroll,
 			setEmblaApi,
 			setCanScrollPrev,
 			setCanScrollNext,

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -322,24 +322,22 @@ export default function Edit( {
 					<SelectControl
 						label={ __( 'Transition', 'rt-carousel' ) }
 						value={ transition }
+						disabled={ autoScroll }
 						options={ [
 							{ label: __( 'Slide', 'rt-carousel' ), value: 'slide' },
 							{ label: __( 'Fade', 'rt-carousel' ), value: 'fade' },
 						] }
-						onChange={ ( value ) => {
-							const nextTransition = value as CarouselAttributes[ 'transition' ];
-							const nextAttributes: Partial< CarouselAttributes > = {
-								transition: nextTransition,
-							};
-							if ( nextTransition === 'fade' ) {
-								nextAttributes.autoScroll = false;
-							}
-							setAttributes( nextAttributes );
-						} }
-						help={ __(
-							'Choose how slides transition: sliding horizontally or cross-fading.',
-							'rt-carousel',
-						) }
+						onChange={ ( value ) =>
+							setAttributes( { transition: value as CarouselAttributes[ 'transition' ] } )
+						}
+						help={
+							autoScroll
+								? __( 'Auto Scroll does not support transitions.', 'rt-carousel' )
+								: __(
+									'Choose how slides transition: sliding horizontally or cross-fading.',
+									'rt-carousel',
+								)
+						}
 					/>
 					<ToggleControl
 						label={ __( 'Loop', 'rt-carousel' ) }
@@ -503,73 +501,77 @@ export default function Edit( {
 						</>
 					) }
 				</PanelBody>
-				{ transition !== 'fade' && (
-					<PanelBody
-						title={ __( 'Auto Scroll', 'rt-carousel' ) }
-						initialOpen={ false }
-					>
-						<ToggleControl
-							label={ __( 'Enable Auto Scroll', 'rt-carousel' ) }
-							checked={ autoScroll }
-							onChange={ ( value ) => setAttributes( {
+				<PanelBody
+					title={ __( 'Auto Scroll', 'rt-carousel' ) }
+					initialOpen={ false }
+				>
+					<ToggleControl
+						label={ __( 'Enable Auto Scroll', 'rt-carousel' ) }
+						checked={ autoScroll }
+						onChange={ ( value ) => {
+							const nextAttributes: Partial< CarouselAttributes > = {
 								autoScroll: value,
 								autoplay: value ? false : autoplay,
 								loop: ( value && autoScrollDirection === 'backward' ) ? true : loop,
-							} ) }
+							};
+							if ( value ) {
+								nextAttributes.transition = 'slide';
+							}
+							setAttributes( nextAttributes );
+						} }
+					/>
+					{ autoScroll && ( <>
+						<RangeControl
+							label={ __( 'Speed', 'rt-carousel' ) }
+							value={ autoScrollSpeed }
+							onChange={ ( value ) =>
+								setAttributes( { autoScrollSpeed: value ?? 2 } )
+							}
+							min={ 1 }
+							max={ 10 }
 						/>
-						{ autoScroll && ( <>
-							<RangeControl
-								label={ __( 'Speed', 'rt-carousel' ) }
-								value={ autoScrollSpeed }
-								onChange={ ( value ) =>
-									setAttributes( { autoScrollSpeed: value ?? 2 } )
-								}
-								min={ 1 }
-								max={ 10 }
-							/>
-							<SelectControl
-								label={ __( 'Direction', 'rt-carousel' ) }
-								value={ autoScrollDirection }
-								options={ [
-									{ label: __( 'Forward', 'rt-carousel' ), value: 'forward' },
-									{ label: __( 'Backward', 'rt-carousel' ), value: 'backward' },
-								] }
-								onChange={ ( value ) =>
-									setAttributes( {
-										autoScrollDirection: value as CarouselAttributes['autoScrollDirection'],
-										loop: value === 'backward' ? true : loop,
-									} )
-								}
-							/>
-							<RangeControl
-								label={ __( 'Start Delay (ms)', 'rt-carousel' ) }
-								value={ autoScrollStartDelay }
-								onChange={ ( value ) =>
-									setAttributes( { autoScrollStartDelay: value ?? 1000 } )
-								}
-								min={ 0 }
-								max={ 10000 }
-								step={ 100 }
-							/>
-							<ToggleControl
-								label={ __( 'Stop on Interaction', 'rt-carousel' ) }
-								checked={ autoScrollStopOnInteraction }
-								onChange={ ( value ) =>
-									setAttributes( { autoScrollStopOnInteraction: value } )
-								}
-								help={ __( 'Stop auto scroll when user interacts with carousel.', 'rt-carousel' ) }
-							/>
-							<ToggleControl
-								label={ __( 'Stop on Mouse Enter', 'rt-carousel' ) }
-								checked={ autoScrollStopOnMouseEnter }
-								onChange={ ( value ) =>
-									setAttributes( { autoScrollStopOnMouseEnter: value } )
-								}
-								help={ __( 'Stop auto scroll when mouse hovers over carousel.', 'rt-carousel' ) }
-							/>
-						</> ) }
-					</PanelBody>
-				) }
+						<SelectControl
+							label={ __( 'Direction', 'rt-carousel' ) }
+							value={ autoScrollDirection }
+							options={ [
+								{ label: __( 'Forward', 'rt-carousel' ), value: 'forward' },
+								{ label: __( 'Backward', 'rt-carousel' ), value: 'backward' },
+							] }
+							onChange={ ( value ) =>
+								setAttributes( {
+									autoScrollDirection: value as CarouselAttributes['autoScrollDirection'],
+									loop: value === 'backward' ? true : loop,
+								} )
+							}
+						/>
+						<RangeControl
+							label={ __( 'Start Delay (ms)', 'rt-carousel' ) }
+							value={ autoScrollStartDelay }
+							onChange={ ( value ) =>
+								setAttributes( { autoScrollStartDelay: value ?? 1000 } )
+							}
+							min={ 0 }
+							max={ 10000 }
+							step={ 100 }
+						/>
+						<ToggleControl
+							label={ __( 'Stop on Interaction', 'rt-carousel' ) }
+							checked={ autoScrollStopOnInteraction }
+							onChange={ ( value ) =>
+								setAttributes( { autoScrollStopOnInteraction: value } )
+							}
+							help={ __( 'Stop auto scroll when user interacts with carousel.', 'rt-carousel' ) }
+						/>
+						<ToggleControl
+							label={ __( 'Stop on Mouse Enter', 'rt-carousel' ) }
+							checked={ autoScrollStopOnMouseEnter }
+							onChange={ ( value ) =>
+								setAttributes( { autoScrollStopOnMouseEnter: value } )
+							}
+							help={ __( 'Stop auto scroll when mouse hovers over carousel.', 'rt-carousel' ) }
+						/>
+					</> ) }
+				</PanelBody>
 			</InspectorControls>
 			<InspectorAdvancedControls>
 				<TextControl

--- a/src/blocks/carousel/editor-context.ts
+++ b/src/blocks/carousel/editor-context.ts
@@ -16,6 +16,7 @@ export type EditorCarouselContextType = {
 	scrollSnaps: number[];
 	slideCount: number;
 	useTabs?: boolean;
+	autoScroll?: boolean;
 	carouselOptions: Omit<Partial<CarouselAttributes>, 'slidesToScroll'> & {
 		slidesToScroll?: number | string;
 		duration?: number;
@@ -37,6 +38,7 @@ const defaultValue: EditorCarouselContextType = {
 	scrollSnaps: [],
 	slideCount: 0,
 	useTabs: false,
+	autoScroll: false,
 	carouselOptions: {},
 };
 

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -72,7 +72,7 @@ export default function Save( {
 			'Slide {{currentSlide}} of {{totalSlides}}',
 			'rt-carousel',
 		),
-		autoScroll: ( transition !== 'fade' && autoScroll ) ? {
+		autoScroll: autoScroll ? {
 			speed: autoScrollSpeed,
 			direction: autoScrollDirection,
 			startDelay: autoScrollStartDelay,

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -72,7 +72,7 @@ export default function Save( {
 			'Slide {{currentSlide}} of {{totalSlides}}',
 			'rt-carousel',
 		),
-		autoScroll: autoScroll ? {
+		autoScroll: ( transition !== 'fade' && autoScroll ) ? {
 			speed: autoScrollSpeed,
 			direction: autoScrollDirection,
 			startDelay: autoScrollStartDelay,

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -320,7 +320,7 @@ store( 'rt-carousel/carousel', {
 						plugins.push( Autoplay( context.autoplay as AutoplayOptionsType ) );
 					}
 
-					if ( context.autoScroll ) {
+					if ( context.autoScroll && context.transition !== 'fade' ) {
 						plugins.push( AutoScroll( context.autoScroll as AutoScrollOptionsType ) );
 					}
 

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -129,11 +129,11 @@ store( 'rt-carousel/carousel', {
 	state: {
 		get canScrollPrev() {
 			const context = getContext<CarouselContext>();
-			return context.canScrollPrev;
+			return context.autoScroll ? true : context.canScrollPrev;
 		},
 		get canScrollNext() {
 			const context = getContext<CarouselContext>();
-			return context.canScrollNext;
+			return context.autoScroll ? true : context.canScrollNext;
 		},
 	},
 	actions: {
@@ -320,7 +320,7 @@ store( 'rt-carousel/carousel', {
 						plugins.push( Autoplay( context.autoplay as AutoplayOptionsType ) );
 					}
 
-					if ( context.autoScroll && context.transition !== 'fade' ) {
+					if ( context.autoScroll ) {
 						plugins.push( AutoScroll( context.autoScroll as AutoScrollOptionsType ) );
 					}
 

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -62,6 +62,22 @@ jest.mock( 'embla-carousel-fade', () => ( {
 } ) );
 
 /**
+ * Mock embla-carousel-auto-scroll module.
+ */
+jest.mock( 'embla-carousel-auto-scroll', () => ( {
+	__esModule: true,
+	default: jest.fn( () => ( {
+		name: 'autoScroll',
+		options: {},
+		init: jest.fn(),
+		destroy: jest.fn(),
+		play: jest.fn(),
+		stop: jest.fn(),
+		isPlaying: jest.fn( () => false ),
+	} ) ),
+} ) );
+
+/**
  * Mock WordPress block editor components.
  */
 jest.mock( '@wordpress/block-editor', () => ( {


### PR DESCRIPTION

## Summary
This pull request enhances the Carousel block by improving support for the Auto Scroll feature and ensuring a better user experience when it is enabled. The most important changes include UI updates to disable incompatible options when Auto Scroll is active, logic changes to enforce compatible settings, and expanded test coverage to ensure correct behavior.

**UI/UX improvements for Auto Scroll:**

* The `Transition` dropdown in the carousel editor is now disabled when Auto Scroll is enabled, and a contextual help message is shown to inform users that transitions are not supported with Auto Scroll.
* Enabling Auto Scroll automatically switches the transition to `'slide'` to prevent incompatible settings.

**Logic updates:**

* The carousel’s previous/next navigation buttons are always enabled when Auto Scroll is active, regardless of whether scrolling is otherwise possible. [[1]](diffhunk://#diff-dc96004b8d23f636ff4e3f06a0e082cbf29e70035aeff49ac3de0c0646a7983bL61-R62) [[2]](diffhunk://#diff-dc96004b8d23f636ff4e3f06a0e082cbf29e70035aeff49ac3de0c0646a7983bL73-R74)
* The internal state selectors `canScrollPrev` and `canScrollNext` now always return `true` when Auto Scroll is enabled, ensuring consistent navigation behavior.

**Test coverage and mocks:**

* Added and updated tests to verify that the UI disables transitions and switches to `'slide'` when enabling Auto Scroll, and that navigation and plugin logic behave correctly with Auto Scroll active. [[1]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22R260) [[2]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22R286) [[3]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22R307-R345) [[4]](diffhunk://#diff-e5bc337f0145ee5a5978098e1f7b2a98dcadb796498aa53dcabe2c33fc5d81e1R178-R200) [[5]](diffhunk://#diff-e5bc337f0145ee5a5978098e1f7b2a98dcadb796498aa53dcabe2c33fc5d81e1R229-R251) [[6]](diffhunk://#diff-e5bc337f0145ee5a5978098e1f7b2a98dcadb796498aa53dcabe2c33fc5d81e1R963-R1012)
* Introduced a mock for the `embla-carousel-auto-scroll` plugin to support new and existing tests.
* Added the `embla-carousel-auto-scroll` import to the view tests to support plugin usage.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

<!-- 'Closes' will automatically close the linked issue when this PR is merged. -->
<!-- 'Relates to' is for issues that are relevant but won't be closed by this PR. -->
Closes https://github.com/rtCamp/rt-carousel/issues/162

## What changed

- Disabled transtion control when autoscroll is enabled.

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [x] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
