### PR TITLE
Fixes issues with tab not able to edit tab title and also removes tab lists when tabs are toggled off

### DIFF
--- a/src/blocks/carousel/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/__tests__/edit.test.tsx
@@ -78,6 +78,10 @@ jest.mock( '@wordpress/components', () => {
 	};
 } );
 
+const mockInsertBlock = jest.fn();
+const mockRemoveBlocks = jest.fn();
+let mockBlocks: unknown[] = [];
+
 type BlockEditorMockSelectors = {
 	getBlockCount: () => number;
 	getBlocks: () => unknown[];
@@ -95,30 +99,33 @@ type MockSelect = {
 
 type MockUseSelectCallback = ( select: MockSelect ) => unknown;
 
+const mockSelect = ( ( storeName: string ) => {
+	if ( storeName === 'core/block-editor' ) {
+		return {
+			getBlockCount: () => mockBlockCount,
+			getBlocks: () => mockBlocks,
+		};
+	}
+
+	if ( storeName === 'core/blocks' ) {
+		return {
+			getBlockTypes: () => [],
+		};
+	}
+
+	return {};
+} ) as MockSelect;
+
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: jest.fn( () => ( {
 		replaceInnerBlocks: jest.fn(),
-		insertBlock: jest.fn(),
+		insertBlock: mockInsertBlock,
+		removeBlocks: mockRemoveBlocks,
 	} ) ),
+	select: jest.fn( ( storeName: string ) => mockSelect( storeName ) ),
+	useRegistry: jest.fn( () => ( { select: mockSelect } ) ),
 	useSelect: jest.fn( ( selector: MockUseSelectCallback ) => {
-		const select = ( ( storeName: string ) => {
-			if ( storeName === 'core/block-editor' ) {
-				return {
-					getBlockCount: () => mockBlockCount,
-					getBlocks: () => [],
-				};
-			}
-
-			if ( storeName === 'core/blocks' ) {
-				return {
-					getBlockTypes: () => [],
-				};
-			}
-
-			return {};
-		} ) as MockSelect;
-
-		return selector( select );
+		return selector( mockSelect );
 	} ),
 } ) );
 
@@ -356,9 +363,14 @@ describe( 'Carousel Edit setup flow', () => {
 } );
 
 describe( 'useTabs toggle', () => {
-	it( 'renders Use as Tabs toggle when inner blocks exist', () => {
+	beforeEach( () => {
 		mockBlockCount = 2;
+		mockBlocks = [];
+		mockInsertBlock.mockClear();
+		mockRemoveBlocks.mockClear();
+	} );
 
+	it( 'renders Use as Tabs toggle when inner blocks exist', () => {
 		render(
 			<Edit
 				attributes={ createAttributes() }
@@ -373,5 +385,89 @@ describe( 'useTabs toggle', () => {
 
 		expect( toggleCall ).toBeDefined();
 		expect( toggleCall[ 0 ].checked ).toBe( false );
+	} );
+
+	it( 'inserts a tab list block when toggling Use as Tabs ON if no tab list exists', () => {
+		mockBlocks = [
+			{ name: 'rt-carousel/carousel-viewport', clientId: 'viewport-1', innerBlocks: [] },
+		];
+		const setAttributes = jest.fn();
+
+		render(
+			<Edit
+				attributes={ createAttributes() }
+				setAttributes={ setAttributes }
+				clientId="test-client-id"
+			/>,
+		);
+
+		const toggleCall = ( ToggleControl as unknown as jest.Mock ).mock.calls.find(
+			( [ props ] ) => props.label === 'Use as Tabs',
+		);
+
+		toggleCall[ 0 ].onChange( true );
+
+		expect( setAttributes ).toHaveBeenCalledWith( expect.objectContaining( { useTabs: true } ) );
+		expect( mockInsertBlock ).toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'rt-carousel/carousel-tab-list' } ),
+			0,
+			'test-client-id',
+		);
+	} );
+
+	it( 'does not insert a second tab list block when toggling Use as Tabs ON if one already exists', () => {
+		mockBlocks = [
+			{ name: 'rt-carousel/carousel-tab-list', clientId: 'existing-tab-list', innerBlocks: [] },
+			{ name: 'rt-carousel/carousel-viewport', clientId: 'viewport-1', innerBlocks: [] },
+		];
+		const setAttributes = jest.fn();
+
+		render(
+			<Edit
+				attributes={ createAttributes() }
+				setAttributes={ setAttributes }
+				clientId="test-client-id"
+			/>,
+		);
+
+		const toggleCall = ( ToggleControl as unknown as jest.Mock ).mock.calls.find(
+			( [ props ] ) => props.label === 'Use as Tabs',
+		);
+
+		toggleCall[ 0 ].onChange( true );
+
+		expect( setAttributes ).toHaveBeenCalledWith( expect.objectContaining( { useTabs: true } ) );
+		expect( mockInsertBlock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'removes all tab list blocks (including nested ones) when toggling Use as Tabs OFF', () => {
+		mockBlocks = [
+			{ name: 'rt-carousel/carousel-tab-list', clientId: 'top-tab-list', innerBlocks: [] },
+			{
+				name: 'core/group',
+				clientId: 'group-1',
+				innerBlocks: [
+					{ name: 'rt-carousel/carousel-tab-list', clientId: 'nested-tab-list', innerBlocks: [] },
+				],
+			},
+		];
+		const setAttributes = jest.fn();
+
+		render(
+			<Edit
+				attributes={ { ...createAttributes(), useTabs: true } }
+				setAttributes={ setAttributes }
+				clientId="test-client-id"
+			/>,
+		);
+
+		const toggleCall = ( ToggleControl as unknown as jest.Mock ).mock.calls.find(
+			( [ props ] ) => props.label === 'Use as Tabs',
+		);
+
+		toggleCall[ 0 ].onChange( false );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { useTabs: false } );
+		expect( mockRemoveBlocks ).toHaveBeenCalledWith( [ 'top-tab-list', 'nested-tab-list' ] );
 	} );
 } );

--- a/src/blocks/carousel/__tests__/types.test.ts
+++ b/src/blocks/carousel/__tests__/types.test.ts
@@ -12,7 +12,7 @@
  * @package
  */
 
-import { findBlockDeep, type CarouselAttributes, type CarouselContext } from '../types';
+import { findBlockDeep, findAllBlocksDeep, type CarouselAttributes, type CarouselContext } from '../types';
 
 describe( 'CarouselAttributes Type', () => {
 	describe( 'Structure Validation', () => {
@@ -719,5 +719,28 @@ describe( 'findBlockDeep', () => {
 	it( 'handles blocks without innerBlocks', () => {
 		const tree = [ { name: 'a', clientId: '1' } ];
 		expect( findBlockDeep( tree, 'a' )?.clientId ).toBe( '1' );
+	} );
+} );
+
+describe( 'findAllBlocksDeep', () => {
+	it( 'returns all matching blocks at all nesting levels', () => {
+		const tree = [
+			{
+				name: 'target',
+				clientId: '1',
+				innerBlocks: [
+					{ name: 'other', clientId: '2', innerBlocks: [] },
+					{ name: 'target', clientId: '3', innerBlocks: [] },
+				],
+			},
+			{ name: 'target', clientId: '4', innerBlocks: [] },
+		];
+		const matches = findAllBlocksDeep( tree, 'target' );
+		expect( matches.map( ( b ) => b.clientId ) ).toEqual( [ '1', '3', '4' ] );
+	} );
+
+	it( 'returns empty array when no blocks match', () => {
+		const tree = [ { name: 'a', clientId: '1', innerBlocks: [] } ];
+		expect( findAllBlocksDeep( tree, 'missing' ) ).toEqual( [] );
 	} );
 } );

--- a/src/blocks/carousel/carousel-tab-list/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/carousel-tab-list/__tests__/edit.test.tsx
@@ -37,6 +37,14 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	ColorPalette: () => null,
 } ) );
 
+jest.mock( '@wordpress/components', () => {
+	const Passthrough = ( { children }: { children?: React.ReactNode } ) => <>{ children }</>;
+	return {
+		PanelBody: Passthrough,
+		BaseControl: Passthrough,
+	};
+} );
+
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn( () => 2 ),
 } ) );

--- a/src/blocks/carousel/carousel-tab-list/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/carousel-tab-list/__tests__/edit.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the carousel tab list edit component.
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import Edit from '../edit';
+import { EditorCarouselContext } from '../../editor-context';
+import type { TabListAttributes } from '../types';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: jest.fn( ( props = {} ) => ( {
+		...props,
+		ref: jest.fn(),
+	} ) ),
+	InspectorControls: ( { children }: { children: React.ReactNode } ) => children,
+	RichText: ( props: {
+		value?: string;
+		placeholder?: string;
+		tagName?: keyof JSX.IntrinsicElements;
+		role?: string;
+		'aria-selected'?: boolean;
+		className?: string;
+	} ) => {
+		const Tag = props.tagName || 'span';
+		return (
+			<Tag
+				role={ props.role }
+				aria-selected={ props[ 'aria-selected' ] }
+				className={ props.className }
+				data-testid="rich-text-tab"
+			>
+				{ props.value || props.placeholder }
+			</Tag>
+		);
+	},
+	ColorPalette: () => null,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn( () => 2 ),
+} ) );
+
+describe( 'Carousel Tab List Edit Component', () => {
+	const defaultAttributes: TabListAttributes = {
+		labels: [ 'Tab 1', 'Tab 2' ],
+	};
+
+	it( 'renders tabs as editable span elements with role="tab" instead of button elements', () => {
+		render(
+			<EditorCarouselContext.Provider
+				value={ {
+					emblaApi: undefined,
+					setEmblaApi: jest.fn(),
+					canScrollPrev: false,
+					canScrollNext: false,
+					setCanScrollPrev: jest.fn(),
+					setCanScrollNext: jest.fn(),
+					scrollProgress: 0,
+					setScrollProgress: jest.fn(),
+					selectedIndex: 0,
+					setSelectedIndex: jest.fn(),
+					scrollSnaps: [],
+					slideCount: 2,
+					carouselOptions: {},
+				} }
+			>
+				<Edit
+					attributes={ defaultAttributes }
+					setAttributes={ jest.fn() }
+					clientId="test-tab-list-1"
+				/>
+			</EditorCarouselContext.Provider>,
+		);
+
+		const tabs = screen.getAllByTestId( 'rich-text-tab' );
+		expect( tabs.length ).toBe( 2 );
+		tabs.forEach( ( tab ) => {
+			expect( tab.tagName.toLowerCase() ).toBe( 'span' );
+			expect( tab ).toHaveAttribute( 'role', 'tab' );
+		} );
+
+		expect( tabs[ 0 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( tabs[ 1 ] ).toHaveAttribute( 'aria-selected', 'false' );
+	} );
+} );

--- a/src/blocks/carousel/carousel-tab-list/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/carousel-tab-list/__tests__/edit.test.tsx
@@ -44,6 +44,10 @@ jest.mock( '@wordpress/data', () => ( {
 describe( 'Carousel Tab List Edit Component', () => {
 	const defaultAttributes: TabListAttributes = {
 		labels: [ 'Tab 1', 'Tab 2' ],
+		activeTabBackgroundColor: '',
+		activeTabTextColor: '',
+		inactiveTabBackgroundColor: '',
+		inactiveTabTextColor: '',
 	};
 
 	it( 'renders tabs as editable span elements with role="tab" instead of button elements', () => {

--- a/src/blocks/carousel/carousel-tab-list/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/carousel-tab-list/__tests__/edit.test.tsx
@@ -2,6 +2,7 @@
  * Unit tests for the carousel tab list edit component.
  */
 
+import type { ReactNode } from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import Edit from '../edit';
@@ -13,13 +14,14 @@ jest.mock( '@wordpress/block-editor', () => ( {
 		...props,
 		ref: jest.fn(),
 	} ) ),
-	InspectorControls: ( { children }: { children: React.ReactNode } ) => children,
+	InspectorControls: ( { children }: { children: ReactNode } ) => children,
 	RichText: ( props: {
 		value?: string;
 		placeholder?: string;
 		tagName?: keyof JSX.IntrinsicElements;
 		role?: string;
 		'aria-selected'?: boolean;
+		tabIndex?: number;
 		className?: string;
 	} ) => {
 		const Tag = props.tagName || 'span';
@@ -27,6 +29,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 			<Tag
 				role={ props.role }
 				aria-selected={ props[ 'aria-selected' ] }
+				tabIndex={ props.tabIndex }
 				className={ props.className }
 				data-testid="rich-text-tab"
 			>
@@ -38,7 +41,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 } ) );
 
 jest.mock( '@wordpress/components', () => {
-	const Passthrough = ( { children }: { children?: React.ReactNode } ) => <>{ children }</>;
+	const Passthrough = ( { children }: { children?: ReactNode } ) => <>{ children }</>;
 	return {
 		PanelBody: Passthrough,
 		BaseControl: Passthrough,
@@ -93,6 +96,8 @@ describe( 'Carousel Tab List Edit Component', () => {
 		} );
 
 		expect( tabs[ 0 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( tabs[ 0 ] ).toHaveAttribute( 'tabindex', '0' );
 		expect( tabs[ 1 ] ).toHaveAttribute( 'aria-selected', 'false' );
+		expect( tabs[ 1 ] ).toHaveAttribute( 'tabindex', '-1' );
 	} );
 } );

--- a/src/blocks/carousel/carousel-tab-list/edit.tsx
+++ b/src/blocks/carousel/carousel-tab-list/edit.tsx
@@ -180,6 +180,7 @@ export default function Edit( {
 							tagName="span"
 							role="tab"
 							aria-selected={ index === carousel.selectedIndex }
+							tabIndex={ index === carousel.selectedIndex ? 0 : -1 }
 							className={ `wp-block-rt-carousel-carousel-tab-list__tab${ index === carousel.selectedIndex ? ' is-active' : '' }` }
 							value={ label }
 							onChange={ ( value ) => setLabelAt( index, value ) }

--- a/src/blocks/carousel/carousel-tab-list/edit.tsx
+++ b/src/blocks/carousel/carousel-tab-list/edit.tsx
@@ -177,8 +177,9 @@ export default function Edit( {
 					return (
 						<RichText
 							key={ `tab-${ index }` }
-							tagName="button"
-							type="button"
+							tagName="span"
+							role="tab"
+							aria-selected={ index === carousel.selectedIndex }
 							className={ `wp-block-rt-carousel-carousel-tab-list__tab${ index === carousel.selectedIndex ? ' is-active' : '' }` }
 							value={ label }
 							onChange={ ( value ) => setLabelAt( index, value ) }

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -85,15 +85,15 @@ export default function Edit( {
 	const { replaceInnerBlocks, insertBlock, removeBlocks } = useDispatch( 'core/block-editor' );
 
 	const hasInnerBlocks = useSelect(
-		( select ) =>
+		( selectStore ) =>
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			( select( 'core/block-editor' ) as any ).getBlockCount( clientId ) > 0,
+			( selectStore( 'core/block-editor' ) as any ).getBlockCount( clientId ) > 0,
 		[ clientId ],
 	);
 
 	const viewportClientId = useSelect(
-		( select ) => {
-			const blockEditor = select( 'core/block-editor' ) as BlockEditorSelectors;
+		( selectStore ) => {
+			const blockEditor = selectStore( 'core/block-editor' ) as BlockEditorSelectors;
 			const innerBlocks = blockEditor.getBlocks( clientId );
 			// Viewport may be nested through columns/group for side-by-side tab layouts.
 			return findBlockDeep( innerBlocks, 'rt-carousel/carousel-viewport' )?.clientId;
@@ -163,9 +163,9 @@ export default function Edit( {
 	}, [ showSetup, setupStep ] );
 
 	// Fetch registered block types for the allowed-blocks token field
-	const blockTypes = useSelect( ( select ) => {
+	const blockTypes = useSelect( ( selectStore ) => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		return ( select( 'core/blocks' ) as any ).getBlockTypes() as BlockConfiguration[];
+		return ( selectStore( 'core/blocks' ) as any ).getBlockTypes() as BlockConfiguration[];
 	}, [] );
 
 	const suggestions = blockTypes?.map( ( block ) => block.name ) || [];

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -19,10 +19,10 @@ import {
 	ToolbarButton,
 } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, select } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
 import { createBlock, type BlockConfiguration } from '@wordpress/blocks';
-import { findBlockDeep, type CarouselAttributes, type BlockEditorSelectors } from './types';
+import { findBlockDeep, findAllBlocksDeep, type CarouselAttributes, type BlockEditorSelectors } from './types';
 import { EditorCarouselContext } from './editor-context';
 import type { EmblaCarouselType } from 'embla-carousel';
 import { getSlideTemplates, type SlideTemplate } from './templates';
@@ -82,7 +82,7 @@ export default function Edit( {
 
 	const slideTemplates = useMemo( getSlideTemplates, [ getSlideTemplates ] );
 
-	const { replaceInnerBlocks, insertBlock } = useDispatch( 'core/block-editor' );
+	const { replaceInnerBlocks, insertBlock, removeBlocks } = useDispatch( 'core/block-editor' );
 
 	const hasInnerBlocks = useSelect(
 		( select ) =>
@@ -347,14 +347,26 @@ export default function Edit( {
 				autoplay: false,
 				axis: 'x',
 			} );
-			// Auto-insert tab list as first child (before viewport)
-			insertBlock(
-				createBlock( 'rt-carousel/carousel-tab-list', {} ),
-				0,
-				clientId,
-			);
+			const blockEditor = select( 'core/block-editor' ) as BlockEditorSelectors;
+			const innerBlocks = blockEditor.getBlocks( clientId );
+			const tabListExists = findBlockDeep( innerBlocks, 'rt-carousel/carousel-tab-list' );
+			if ( ! tabListExists ) {
+				// Auto-insert tab list as first child (before viewport)
+				insertBlock(
+					createBlock( 'rt-carousel/carousel-tab-list', {} ),
+					0,
+					clientId,
+				);
+			}
 		} else {
 			setAttributes( { useTabs: false } );
+			const blockEditor = select( 'core/block-editor' ) as BlockEditorSelectors;
+			const innerBlocks = blockEditor.getBlocks( clientId );
+			const tabListBlocks = findAllBlocksDeep( innerBlocks, 'rt-carousel/carousel-tab-list' );
+			const tabListIds = tabListBlocks.map( ( b ) => b.clientId );
+			if ( tabListIds.length > 0 ) {
+				removeBlocks( tabListIds );
+			}
 		}
 	};
 

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -19,7 +19,7 @@ import {
 	ToolbarButton,
 } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
-import { useSelect, useDispatch, select } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
 import { createBlock, type BlockConfiguration } from '@wordpress/blocks';
 import { findBlockDeep, findAllBlocksDeep, type CarouselAttributes, type BlockEditorSelectors } from './types';
@@ -91,14 +91,17 @@ export default function Edit( {
 		[ clientId ],
 	);
 
-	const viewportClientId = useSelect(
+	const innerBlocks = useSelect(
 		( selectStore ) => {
 			const blockEditor = selectStore( 'core/block-editor' ) as BlockEditorSelectors;
-			const innerBlocks = blockEditor.getBlocks( clientId );
-			// Viewport may be nested through columns/group for side-by-side tab layouts.
-			return findBlockDeep( innerBlocks, 'rt-carousel/carousel-viewport' )?.clientId;
+			return blockEditor.getBlocks( clientId );
 		},
 		[ clientId ],
+	);
+
+	const viewportClientId = useMemo(
+		() => findBlockDeep( innerBlocks, 'rt-carousel/carousel-viewport' )?.clientId,
+		[ innerBlocks ],
 	);
 
 	const addSlide = useCallback( () => {
@@ -347,8 +350,6 @@ export default function Edit( {
 				autoplay: false,
 				axis: 'x',
 			} );
-			const blockEditor = select( 'core/block-editor' ) as BlockEditorSelectors;
-			const innerBlocks = blockEditor.getBlocks( clientId );
 			const tabListExists = findBlockDeep( innerBlocks, 'rt-carousel/carousel-tab-list' );
 			if ( ! tabListExists ) {
 				// Auto-insert tab list as first child (before viewport)
@@ -360,8 +361,6 @@ export default function Edit( {
 			}
 		} else {
 			setAttributes( { useTabs: false } );
-			const blockEditor = select( 'core/block-editor' ) as BlockEditorSelectors;
-			const innerBlocks = blockEditor.getBlocks( clientId );
 			const tabListBlocks = findAllBlocksDeep( innerBlocks, 'rt-carousel/carousel-tab-list' );
 			const tabListIds = tabListBlocks.map( ( b ) => b.clientId );
 			if ( tabListIds.length > 0 ) {

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -86,6 +86,30 @@ export function findBlockDeep<T extends { name: string; innerBlocks?: T[] }>(
 	return undefined;
 }
 
+/**
+ * Depth-first search for all blocks of `name` anywhere in the tree.
+ *
+ * @template {Object} T - Block-like value with a `name` and optional `innerBlocks`.
+ * @param {T[]}    blocks - Block tree to search (must include innerBlocks).
+ * @param {string} name   - Block name to match.
+ * @return {T[]} All matching blocks.
+ */
+export function findAllBlocksDeep<T extends { name: string; innerBlocks?: T[] }>(
+	blocks: T[],
+	name: string,
+): T[] {
+	const result: T[] = [];
+	for ( const block of blocks ) {
+		if ( block.name === name ) {
+			result.push( block );
+		}
+		if ( block.innerBlocks?.length ) {
+			result.push( ...findAllBlocksDeep( block.innerBlocks, name ) );
+		}
+	}
+	return result;
+}
+
 export type CarouselContext = {
 	transition: 'slide' | 'fade';
 	options: EmblaOptionsType & {


### PR DESCRIPTION
## Summary

 The main changes include adding a utility to find all matching blocks in a tree, updating the carousel tab list to use accessible markup, and ensuring tab lists are automatically inserted or removed based on settings. Comprehensive unit tests have also been added to cover these new behaviors.

**Block tree utilities:**
- Added `findAllBlocksDeep` utility to recursively find all blocks of a given name in a block tree, with unit tests verifying its correctness. [[1]](diffhunk://#diff-7a36ce4ecb557918d3808e060ae48142421c3737496f8983d8a0b41d2c326491R89-R112) [[2]](diffhunk://#diff-3622d59688566eecfb9c935b30d8d50e69e86240eacb3acc90b6634ccc92b2cfL15-R15) [[3]](diffhunk://#diff-3622d59688566eecfb9c935b30d8d50e69e86240eacb3acc90b6634ccc92b2cfR724-R746)

**Carousel tab list accessibility and behavior:**
- Updated the tab list to render tabs as `<span>` elements with appropriate ARIA roles (`role="tab"`, `aria-selected`) for accessibility, instead of buttons.
- Added unit tests for the tab list edit component to ensure correct rendering and ARIA attributes.

**Automatic tab list management:**
- In the carousel block editor, automatically inserts a tab list block when tabs are enabled and removes all tab list blocks when tabs are disabled, using the new utility and `removeBlocks` action. [[1]](diffhunk://#diff-ffa3117c45a2cc510ebbb54deb690bf57fac2e02a259a4716aa5406545c6d688L22-R25) [[2]](diffhunk://#diff-ffa3117c45a2cc510ebbb54deb690bf57fac2e02a259a4716aa5406545c6d688L85-R85) [[3]](diffhunk://#diff-ffa3117c45a2cc510ebbb54deb690bf57fac2e02a259a4716aa5406545c6d688R350-R369)
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)
Closes #171, #172

## What changed

- Fixes issues where tab title were not inaccessible when user clicks them to edit.
- Fixes issues where tab being inserted when tab toggle was switched on/off, by removing the tab list

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [x] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
