### PR TITLE
Fixes : Improved tabs block by removing carousel control group and improve block filter logic

### DIFF
--- a/src/blocks/carousel/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/__tests__/edit.test.tsx
@@ -504,12 +504,16 @@ describe( 'useTabs toggle', () => {
 		toggleCall[ 0 ].onChange( true );
 
 		expect( setAttributes ).toHaveBeenCalledWith( expect.objectContaining( { useTabs: true } ) );
-		expect( mockRemoveBlocks ).toHaveBeenCalledWith( [
-			'group-1',
-			'nested-controls',
-			'nested-counter',
-			'nested-dots',
-		] );
+		const removedIds = mockRemoveBlocks.mock.calls[ 0 ][ 0 ];
+		expect( removedIds ).toHaveLength( 4 );
+		expect( removedIds ).toEqual(
+			expect.arrayContaining( [
+				'group-1',
+				'nested-controls',
+				'nested-counter',
+				'nested-dots',
+			] ),
+		);
 	} );
 
 	it( 'restores missing nav blocks into the core/group that actually contains nav elements, ignoring unrelated groups', () => {
@@ -541,12 +545,58 @@ describe( 'useTabs toggle', () => {
 
 		expect( mockInsertBlock ).toHaveBeenCalledWith(
 			expect.objectContaining( { name: 'rt-carousel/carousel-controls' } ),
-			0,
+			undefined,
 			'nav-group-1',
 		);
 		expect( mockInsertBlock ).toHaveBeenCalledWith(
 			expect.objectContaining( { name: 'rt-carousel/carousel-counter' } ),
-			1,
+			undefined,
+			'nav-group-1',
+		);
+	} );
+
+	it( 're-inserts only missing nav blocks (counter and dots) when controls already exist in a nav group', () => {
+		mockBlocks = [
+			{
+				name: 'core/group',
+				clientId: 'nav-group-1',
+				innerBlocks: [
+					{ name: 'rt-carousel/carousel-controls', clientId: 'existing-controls', innerBlocks: [] },
+				],
+			},
+		];
+		const setAttributes = jest.fn();
+
+		render(
+			<Edit
+				attributes={ { ...createAttributes(), useTabs: true } }
+				setAttributes={ setAttributes }
+				clientId="test-client-id"
+			/>,
+		);
+
+		const toggleCall = ( ToggleControl as unknown as jest.Mock ).mock.calls.find(
+			( [ props ] ) => props.label === 'Use as Tabs',
+		);
+
+		toggleCall[ 0 ].onChange( false );
+
+		// Controls already exist — should NOT be inserted again
+		expect( mockInsertBlock ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'rt-carousel/carousel-controls' } ),
+			expect.anything(),
+			expect.anything(),
+		);
+
+		// Missing counter and dots SHOULD be inserted into nav-group-1
+		expect( mockInsertBlock ).toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'rt-carousel/carousel-counter' } ),
+			undefined,
+			'nav-group-1',
+		);
+		expect( mockInsertBlock ).toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'rt-carousel/carousel-dots' } ),
+			undefined,
 			'nav-group-1',
 		);
 	} );

--- a/src/blocks/carousel/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/__tests__/edit.test.tsx
@@ -408,7 +408,7 @@ describe( 'useTabs toggle', () => {
 		toggleCall[ 0 ].onChange( true );
 
 		expect( setAttributes ).toHaveBeenCalledWith(
-			expect.objectContaining( { useTabs: true, transition: 'slide' } ),
+			expect.objectContaining( { useTabs: true, transition: 'slide', autoScroll: false } ),
 		);
 		expect( mockInsertBlock ).toHaveBeenCalledWith(
 			expect.objectContaining( { name: 'rt-carousel/carousel-tab-list' } ),
@@ -439,7 +439,7 @@ describe( 'useTabs toggle', () => {
 		toggleCall[ 0 ].onChange( true );
 
 		expect( setAttributes ).toHaveBeenCalledWith(
-			expect.objectContaining( { useTabs: true, transition: 'slide' } ),
+			expect.objectContaining( { useTabs: true, transition: 'slide', autoScroll: false } ),
 		);
 		expect( mockInsertBlock ).not.toHaveBeenCalled();
 	} );
@@ -510,5 +510,44 @@ describe( 'useTabs toggle', () => {
 			'nested-counter',
 			'nested-dots',
 		] );
+	} );
+
+	it( 'restores missing nav blocks into the core/group that actually contains nav elements, ignoring unrelated groups', () => {
+		mockBlocks = [
+			{ name: 'core/group', clientId: 'unrelated-group', innerBlocks: [] },
+			{
+				name: 'core/group',
+				clientId: 'nav-group-1',
+				innerBlocks: [
+					{ name: 'rt-carousel/carousel-dots', clientId: 'existing-dots', innerBlocks: [] },
+				],
+			},
+		];
+		const setAttributes = jest.fn();
+
+		render(
+			<Edit
+				attributes={ { ...createAttributes(), useTabs: true } }
+				setAttributes={ setAttributes }
+				clientId="test-client-id"
+			/>,
+		);
+
+		const toggleCall = ( ToggleControl as unknown as jest.Mock ).mock.calls.find(
+			( [ props ] ) => props.label === 'Use as Tabs',
+		);
+
+		toggleCall[ 0 ].onChange( false );
+
+		expect( mockInsertBlock ).toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'rt-carousel/carousel-controls' } ),
+			0,
+			'nav-group-1',
+		);
+		expect( mockInsertBlock ).toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'rt-carousel/carousel-counter' } ),
+			1,
+			'nav-group-1',
+		);
 	} );
 } );

--- a/src/blocks/carousel/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/__tests__/edit.test.tsx
@@ -407,7 +407,9 @@ describe( 'useTabs toggle', () => {
 
 		toggleCall[ 0 ].onChange( true );
 
-		expect( setAttributes ).toHaveBeenCalledWith( expect.objectContaining( { useTabs: true } ) );
+		expect( setAttributes ).toHaveBeenCalledWith(
+			expect.objectContaining( { useTabs: true, transition: 'slide' } ),
+		);
 		expect( mockInsertBlock ).toHaveBeenCalledWith(
 			expect.objectContaining( { name: 'rt-carousel/carousel-tab-list' } ),
 			0,
@@ -436,20 +438,16 @@ describe( 'useTabs toggle', () => {
 
 		toggleCall[ 0 ].onChange( true );
 
-		expect( setAttributes ).toHaveBeenCalledWith( expect.objectContaining( { useTabs: true } ) );
+		expect( setAttributes ).toHaveBeenCalledWith(
+			expect.objectContaining( { useTabs: true, transition: 'slide' } ),
+		);
 		expect( mockInsertBlock ).not.toHaveBeenCalled();
 	} );
 
-	it( 'removes all tab list blocks (including nested ones) when toggling Use as Tabs OFF', () => {
+	it( 'removes tab list blocks and re-inserts full nav group container when toggling Use as Tabs OFF and no nav blocks exist', () => {
 		mockBlocks = [
 			{ name: 'rt-carousel/carousel-tab-list', clientId: 'top-tab-list', innerBlocks: [] },
-			{
-				name: 'core/group',
-				clientId: 'group-1',
-				innerBlocks: [
-					{ name: 'rt-carousel/carousel-tab-list', clientId: 'nested-tab-list', innerBlocks: [] },
-				],
-			},
+			{ name: 'rt-carousel/carousel-viewport', clientId: 'viewport-1', innerBlocks: [] },
 		];
 		const setAttributes = jest.fn();
 
@@ -468,6 +466,49 @@ describe( 'useTabs toggle', () => {
 		toggleCall[ 0 ].onChange( false );
 
 		expect( setAttributes ).toHaveBeenCalledWith( { useTabs: false } );
-		expect( mockRemoveBlocks ).toHaveBeenCalledWith( [ 'top-tab-list', 'nested-tab-list' ] );
+		expect( mockRemoveBlocks ).toHaveBeenCalledWith( [ 'top-tab-list' ] );
+		expect( mockInsertBlock ).toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'core/group' } ),
+			undefined,
+			'test-client-id',
+		);
+	} );
+
+	it( 'removes navigation group row containers and navigation blocks when toggling Use as Tabs ON', () => {
+		mockBlocks = [
+			{ name: 'rt-carousel/carousel-viewport', clientId: 'viewport-1', innerBlocks: [] },
+			{
+				name: 'core/group',
+				clientId: 'group-1',
+				innerBlocks: [
+					{ name: 'rt-carousel/carousel-controls', clientId: 'nested-controls', innerBlocks: [] },
+					{ name: 'rt-carousel/carousel-counter', clientId: 'nested-counter', innerBlocks: [] },
+					{ name: 'rt-carousel/carousel-dots', clientId: 'nested-dots', innerBlocks: [] },
+				],
+			},
+		];
+		const setAttributes = jest.fn();
+
+		render(
+			<Edit
+				attributes={ createAttributes() }
+				setAttributes={ setAttributes }
+				clientId="test-client-id"
+			/>,
+		);
+
+		const toggleCall = ( ToggleControl as unknown as jest.Mock ).mock.calls.find(
+			( [ props ] ) => props.label === 'Use as Tabs',
+		);
+
+		toggleCall[ 0 ].onChange( true );
+
+		expect( setAttributes ).toHaveBeenCalledWith( expect.objectContaining( { useTabs: true } ) );
+		expect( mockRemoveBlocks ).toHaveBeenCalledWith( [
+			'group-1',
+			'nested-controls',
+			'nested-counter',
+			'nested-dots',
+		] );
 	} );
 } );

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -364,9 +364,9 @@ export default function Edit( {
 			const navGroupBlocks = innerBlocks.filter(
 				( b ) =>
 					b.name === 'core/group' &&
-					( findBlockDeep( b.innerBlocks, 'rt-carousel/carousel-controls' ) ||
-						findBlockDeep( b.innerBlocks, 'rt-carousel/carousel-counter' ) ||
-						findBlockDeep( b.innerBlocks, 'rt-carousel/carousel-dots' ) ),
+					( findBlockDeep( b.innerBlocks ?? [], 'rt-carousel/carousel-controls' ) ||
+						findBlockDeep( b.innerBlocks ?? [], 'rt-carousel/carousel-counter' ) ||
+						findBlockDeep( b.innerBlocks ?? [], 'rt-carousel/carousel-dots' ) ),
 			);
 			const looseNavBlocks = [
 				...findAllBlocksDeep( innerBlocks, 'rt-carousel/carousel-controls' ),

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -349,6 +349,7 @@ export default function Edit( {
 				containScroll: 'trimSnaps',
 				slidesToScroll: '1',
 				autoplay: false,
+				autoScroll: false,
 				axis: 'x',
 			} );
 			const tabListExists = findBlockDeep( innerBlocks, 'rt-carousel/carousel-tab-list' );
@@ -399,7 +400,13 @@ export default function Edit( {
 				// No navigation blocks exist — insert full nav group row container
 				insertBlock( createNavGroup(), undefined, clientId );
 			} else if ( ! controlsExist || ! counterExist || ! dotsExist ) {
-				const navGroup = innerBlocks.find( ( b ) => b.name === 'core/group' );
+				const navGroup = innerBlocks.find(
+					( b ) =>
+						b.name === 'core/group' &&
+						( findBlockDeep( b.innerBlocks ?? [], 'rt-carousel/carousel-controls' ) ||
+							findBlockDeep( b.innerBlocks ?? [], 'rt-carousel/carousel-counter' ) ||
+							findBlockDeep( b.innerBlocks ?? [], 'rt-carousel/carousel-dots' ) ),
+				);
 				const targetParentId = navGroup ? navGroup.clientId : clientId;
 
 				if ( ! controlsExist ) {

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -412,21 +412,21 @@ export default function Edit( {
 				if ( ! controlsExist ) {
 					insertBlock(
 						createBlock( 'rt-carousel/carousel-controls', {} ),
-						0,
+						undefined,
 						targetParentId,
 					);
 				}
 				if ( ! counterExist ) {
 					insertBlock(
 						createBlock( 'rt-carousel/carousel-counter', {} ),
-						1,
+						undefined,
 						targetParentId,
 					);
 				}
 				if ( ! dotsExist ) {
 					insertBlock(
 						createBlock( 'rt-carousel/carousel-dots', {} ),
-						2,
+						undefined,
 						targetParentId,
 					);
 				}

--- a/src/blocks/carousel/edit.tsx
+++ b/src/blocks/carousel/edit.tsx
@@ -342,6 +342,7 @@ export default function Edit( {
 		if ( value ) {
 			setAttributes( {
 				useTabs: true,
+				transition: 'slide',
 				loop: false,
 				dragFree: false,
 				carouselAlign: 'start',
@@ -359,12 +360,69 @@ export default function Edit( {
 					clientId,
 				);
 			}
+			// Find nav row containers (core/group containing navigation blocks) as well as any standalone nav blocks
+			const navGroupBlocks = innerBlocks.filter(
+				( b ) =>
+					b.name === 'core/group' &&
+					( findBlockDeep( b.innerBlocks, 'rt-carousel/carousel-controls' ) ||
+						findBlockDeep( b.innerBlocks, 'rt-carousel/carousel-counter' ) ||
+						findBlockDeep( b.innerBlocks, 'rt-carousel/carousel-dots' ) ),
+			);
+			const looseNavBlocks = [
+				...findAllBlocksDeep( innerBlocks, 'rt-carousel/carousel-controls' ),
+				...findAllBlocksDeep( innerBlocks, 'rt-carousel/carousel-counter' ),
+				...findAllBlocksDeep( innerBlocks, 'rt-carousel/carousel-dots' ),
+			];
+
+			const idsToRemove = Array.from(
+				new Set( [
+					...navGroupBlocks.map( ( b ) => b.clientId ),
+					...looseNavBlocks.map( ( b ) => b.clientId ),
+				] ),
+			);
+			if ( idsToRemove.length > 0 ) {
+				removeBlocks( idsToRemove );
+			}
 		} else {
 			setAttributes( { useTabs: false } );
 			const tabListBlocks = findAllBlocksDeep( innerBlocks, 'rt-carousel/carousel-tab-list' );
 			const tabListIds = tabListBlocks.map( ( b ) => b.clientId );
 			if ( tabListIds.length > 0 ) {
 				removeBlocks( tabListIds );
+			}
+
+			const controlsExist = findBlockDeep( innerBlocks, 'rt-carousel/carousel-controls' );
+			const counterExist = findBlockDeep( innerBlocks, 'rt-carousel/carousel-counter' );
+			const dotsExist = findBlockDeep( innerBlocks, 'rt-carousel/carousel-dots' );
+
+			if ( ! controlsExist && ! counterExist && ! dotsExist ) {
+				// No navigation blocks exist — insert full nav group row container
+				insertBlock( createNavGroup(), undefined, clientId );
+			} else if ( ! controlsExist || ! counterExist || ! dotsExist ) {
+				const navGroup = innerBlocks.find( ( b ) => b.name === 'core/group' );
+				const targetParentId = navGroup ? navGroup.clientId : clientId;
+
+				if ( ! controlsExist ) {
+					insertBlock(
+						createBlock( 'rt-carousel/carousel-controls', {} ),
+						0,
+						targetParentId,
+					);
+				}
+				if ( ! counterExist ) {
+					insertBlock(
+						createBlock( 'rt-carousel/carousel-counter', {} ),
+						1,
+						targetParentId,
+					);
+				}
+				if ( ! dotsExist ) {
+					insertBlock(
+						createBlock( 'rt-carousel/carousel-dots', {} ),
+						2,
+						targetParentId,
+					);
+				}
 			}
 		}
 	};
@@ -373,26 +431,6 @@ export default function Edit( {
 		<>
 			<InspectorControls>
 				<PanelBody title={ useTabs ? __( 'Tab Settings', 'rt-carousel' ) : __( 'Carousel Settings', 'rt-carousel' ) }>
-					<SelectControl
-						label={ __( 'Transition', 'rt-carousel' ) }
-						value={ transition }
-						disabled={ autoScroll }
-						options={ [
-							{ label: __( 'Slide', 'rt-carousel' ), value: 'slide' },
-							{ label: __( 'Fade', 'rt-carousel' ), value: 'fade' },
-						] }
-						onChange={ ( value ) =>
-							setAttributes( { transition: value as CarouselAttributes[ 'transition' ] } )
-						}
-						help={
-							autoScroll
-								? __( 'Auto Scroll does not support transitions.', 'rt-carousel' )
-								: __(
-									'Choose how slides transition: sliding horizontally or cross-fading.',
-									'rt-carousel',
-								)
-						}
-					/>
 					<ToggleControl
 						label={ __( 'Use as Tabs', 'rt-carousel' ) }
 						checked={ useTabs }
@@ -404,6 +442,26 @@ export default function Edit( {
 					/>
 					{ ! useTabs && (
 						<>
+							<SelectControl
+								label={ __( 'Transition', 'rt-carousel' ) }
+								value={ transition }
+								disabled={ autoScroll }
+								options={ [
+									{ label: __( 'Slide', 'rt-carousel' ), value: 'slide' },
+									{ label: __( 'Fade', 'rt-carousel' ), value: 'fade' },
+								] }
+								onChange={ ( value ) =>
+									setAttributes( { transition: value as CarouselAttributes[ 'transition' ] } )
+								}
+								help={
+									autoScroll
+										? __( 'Auto Scroll does not support transitions.', 'rt-carousel' )
+										: __(
+											'Choose how slides transition: sliding horizontally or cross-fading.',
+											'rt-carousel',
+										)
+								}
+							/>
 							<ToggleControl
 								label={ __( 'Loop', 'rt-carousel' ) }
 								checked={ loop }


### PR DESCRIPTION
## Summary

This pull request updates the carousel block's "Use as Tabs" toggle logic and related tests to improve navigation block handling and ensure correct attribute updates. The main changes include more robust removal and insertion of navigation blocks when toggling the "Use as Tabs" option, setting the correct transition type, and updating test cases to reflect the new logic.

**Enhancements to "Use as Tabs" toggle logic:**

* When enabling "Use as Tabs", the `transition` attribute is now set to `'slide'` in addition to `useTabs: true`, ensuring consistent behavior. [[1]](diffhunk://#diff-ffa3117c45a2cc510ebbb54deb690bf57fac2e02a259a4716aa5406545c6d688R345) [[2]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22L410-R412) [[3]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22L439-R494)
* Enabling "Use as Tabs" removes all navigation group containers (`core/group` containing navigation blocks) and any standalone navigation blocks (`carousel-controls`, `carousel-counter`, `carousel-dots`). [[1]](diffhunk://#diff-ffa3117c45a2cc510ebbb54deb690bf57fac2e02a259a4716aa5406545c6d688R363-R444) [[2]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22L439-R494) [[3]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22L468-R512)
* Disabling "Use as Tabs" removes all tab list blocks and, if no navigation blocks exist, re-inserts a full navigation group container. If some navigation blocks are missing, only the missing ones are re-inserted. [[1]](diffhunk://#diff-ffa3117c45a2cc510ebbb54deb690bf57fac2e02a259a4716aa5406545c6d688R363-R444) [[2]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22L439-R494)

**Test updates:**

* Test cases have been updated and expanded to verify the correct removal and insertion of navigation and tab list blocks, and to check that the correct attributes are set when toggling "Use as Tabs" on and off. [[1]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22L410-R412) [[2]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22L439-R494) [[3]](diffhunk://#diff-a3407586ef52cb4039a64ba6b98945a936517ad71ef949a83a01a6ec98605b22L468-R512)

**UI adjustments:**

* The "Use as Tabs" toggle is now always displayed in the inspector controls, and the "Transition" and "Loop" controls are only shown when "Use as Tabs" is disabled.
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

Closes #174 

## What changed

- Fixes issue with carousel transition, remove transition control when tab mode is enabled.
- Switch to default slide transition when tab mode is enabled.
- Remove control group when tab mode is enabled.

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
