### PR TITLE
Fix carousel tab indexing and improve mobile responsiveness

### DIFF
--- a/src/blocks/carousel/carousel-tab-list/__tests__/view.test.ts
+++ b/src/blocks/carousel/carousel-tab-list/__tests__/view.test.ts
@@ -216,6 +216,15 @@ describe( 'getTabTabIndex (roving tabindex)', () => {
 		);
 		expect( storeConfig!.callbacks.getTabTabIndex() ).toBe( '0' );
 	} );
+
+	it( 'returns "-1" when snap or snap.index is undefined', () => {
+		( getContext as jest.Mock ).mockReturnValue( {
+			carouselId: 'c1',
+			selectedIndex: 0,
+			snap: undefined,
+		} );
+		expect( storeConfig!.callbacks.getTabTabIndex() ).toBe( '-1' );
+	} );
 } );
 
 describe( 'getKeyFeatureDotText', () => {

--- a/src/blocks/carousel/carousel-tab-list/__tests__/view.test.ts
+++ b/src/blocks/carousel/carousel-tab-list/__tests__/view.test.ts
@@ -210,9 +210,16 @@ describe( 'getTabTabIndex (roving tabindex)', () => {
 		expect( storeConfig!.callbacks.getTabTabIndex() ).toBe( '-1' );
 	} );
 
-	it( 'returns "0" for the first tab when selectedIndex is -1 or uninitialized', () => {
+	it( 'returns "0" for the first tab when selectedIndex is -1', () => {
 		( getContext as jest.Mock ).mockReturnValue(
 			mockContext( { selectedIndex: -1, snap: { index: 0 } } ),
+		);
+		expect( storeConfig!.callbacks.getTabTabIndex() ).toBe( '0' );
+	} );
+
+	it( 'returns "0" for the first tab when selectedIndex is undefined (uninitialized)', () => {
+		( getContext as jest.Mock ).mockReturnValue(
+			mockContext( { selectedIndex: undefined as unknown as number, snap: { index: 0 } } ),
 		);
 		expect( storeConfig!.callbacks.getTabTabIndex() ).toBe( '0' );
 	} );

--- a/src/blocks/carousel/carousel-tab-list/__tests__/view.test.ts
+++ b/src/blocks/carousel/carousel-tab-list/__tests__/view.test.ts
@@ -209,6 +209,13 @@ describe( 'getTabTabIndex (roving tabindex)', () => {
 		);
 		expect( storeConfig!.callbacks.getTabTabIndex() ).toBe( '-1' );
 	} );
+
+	it( 'returns "0" for the first tab when selectedIndex is -1 or uninitialized', () => {
+		( getContext as jest.Mock ).mockReturnValue(
+			mockContext( { selectedIndex: -1, snap: { index: 0 } } ),
+		);
+		expect( storeConfig!.callbacks.getTabTabIndex() ).toBe( '0' );
+	} );
 } );
 
 describe( 'getKeyFeatureDotText', () => {

--- a/src/blocks/carousel/carousel-tab-list/style.scss
+++ b/src/blocks/carousel/carousel-tab-list/style.scss
@@ -45,11 +45,8 @@
 
 		&:focus-visible {
 
-			/* Visible by default (WCAG 2.4.7). Use currentColor unconditionally
-			 * because --rt-tab-border-color defaults to transparent. */
-			outline-color: currentcolor;
-			outline-style: solid;
-			outline-width: 2px;
+			/* Visible by default (WCAG 2.4.7). High contrast outline for keyboard navigation */
+			outline: 2px solid var(--wp-admin-theme-color, #007cba);
 			outline-offset: 2px;
 		}
 
@@ -61,9 +58,22 @@
 	}
 }
 
+@media (max-width: 1024px) {
+
+	.wp-block-rt-carousel-carousel-tab-list {
+		flex-direction: column;
+
+		&__tab {
+			width: 100%;
+			box-sizing: border-box;
+		}
+	}
+}
+
 @media (prefers-reduced-motion: reduce) {
 
 	.wp-block-rt-carousel-carousel-tab-list__tab {
 		transition: none;
 	}
 }
+

--- a/src/blocks/carousel/carousel-tab-list/style.scss
+++ b/src/blocks/carousel/carousel-tab-list/style.scss
@@ -32,7 +32,9 @@
 		align-items: center;
 		justify-content: center;
 		padding: 0.5em 1em;
-		border: var(--rt-tab-border-width) var(--rt-tab-border-style) var(--rt-tab-border-color);
+		border-width: var(--rt-tab-border-width);
+		border-style: var(--rt-tab-border-style);
+		border-color: var(--rt-tab-border-color);
 		background: var(--rt-tab-inactive-bg);
 		color: var(--rt-tab-inactive-color);
 		cursor: pointer;
@@ -45,7 +47,8 @@
 
 		&:focus-visible {
 
-			/* Visible by default (WCAG 2.4.7). High contrast outline for keyboard navigation */
+			/* Visible by default (WCAG 2.4.7). High contrast outline for keyboard
+			 * navigation. */
 			outline: 2px solid var(--wp-admin-theme-color, #007cba);
 			outline-offset: 2px;
 		}

--- a/src/blocks/carousel/carousel-tab-list/style.scss
+++ b/src/blocks/carousel/carousel-tab-list/style.scss
@@ -60,10 +60,10 @@
 
 @media (max-width: 1024px) {
 
-	.wp-block-rt-carousel-carousel-tab-list {
+	.wp-block-rt-carousel-carousel-tab-list,
+	.wp-block-rt-carousel-carousel-tab-list.is-layout-flex {
 		max-width: 100%;
-		/* stylelint-disable-next-line declaration-no-important */
-		flex-wrap: nowrap !important;
+		flex-wrap: nowrap;
 		overflow-x: auto;
 		-webkit-overflow-scrolling: touch;
 		scrollbar-width: none;
@@ -72,7 +72,7 @@
 			display: none;
 		}
 
-		&__tab {
+		.wp-block-rt-carousel-carousel-tab-list__tab {
 			flex: 0 0 auto;
 			white-space: nowrap;
 		}

--- a/src/blocks/carousel/carousel-tab-list/style.scss
+++ b/src/blocks/carousel/carousel-tab-list/style.scss
@@ -66,10 +66,21 @@
 		flex-wrap: nowrap;
 		overflow-x: auto;
 		-webkit-overflow-scrolling: touch;
-		scrollbar-width: none;
+		scrollbar-width: thin;
+		scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+		padding-bottom: 4px;
 
 		&::-webkit-scrollbar {
-			display: none;
+			height: 4px;
+		}
+
+		&::-webkit-scrollbar-track {
+			background: transparent;
+		}
+
+		&::-webkit-scrollbar-thumb {
+			background-color: rgba(0, 0, 0, 0.2);
+			border-radius: 2px;
 		}
 
 		.wp-block-rt-carousel-carousel-tab-list__tab {

--- a/src/blocks/carousel/carousel-tab-list/style.scss
+++ b/src/blocks/carousel/carousel-tab-list/style.scss
@@ -61,11 +61,20 @@
 @media (max-width: 1024px) {
 
 	.wp-block-rt-carousel-carousel-tab-list {
-		flex-direction: column;
+		max-width: 100%;
+		/* stylelint-disable-next-line declaration-no-important */
+		flex-wrap: nowrap !important;
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: none;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
 
 		&__tab {
-			width: 100%;
-			box-sizing: border-box;
+			flex: 0 0 auto;
+			white-space: nowrap;
 		}
 	}
 }

--- a/src/blocks/carousel/carousel-tab-list/view.ts
+++ b/src/blocks/carousel/carousel-tab-list/view.ts
@@ -94,11 +94,15 @@ store( 'rt-carousel/carousel', {
 		 * inactive tabs are focusable only via arrow keys (tabindex=-1). */
 		getTabTabIndex: (): string => {
 			const context = getContext< TabContext >();
+			const snapIndex = context.snap?.index;
+			if ( typeof snapIndex !== 'number' ) {
+				return '-1';
+			}
 			const selectedIndex =
 				typeof context.selectedIndex === 'number' && context.selectedIndex >= 0
 					? context.selectedIndex
 					: 0;
-			const isActive = selectedIndex === ( context.snap?.index ?? 0 );
+			const isActive = selectedIndex === snapIndex;
 			return isActive ? '0' : '-1';
 		},
 	},

--- a/src/blocks/carousel/carousel-tab-list/view.ts
+++ b/src/blocks/carousel/carousel-tab-list/view.ts
@@ -94,8 +94,13 @@ store( 'rt-carousel/carousel', {
 		 * inactive tabs are focusable only via arrow keys (tabindex=-1). */
 		getTabTabIndex: (): string => {
 			const context = getContext< TabContext >();
-			const isActive = context.selectedIndex === context.snap?.index;
+			const selectedIndex =
+				typeof context.selectedIndex === 'number' && context.selectedIndex >= 0
+					? context.selectedIndex
+					: 0;
+			const isActive = selectedIndex === ( context.snap?.index ?? 0 );
 			return isActive ? '0' : '-1';
 		},
 	},
 } as CarouselStore );
+

--- a/src/blocks/carousel/save.tsx
+++ b/src/blocks/carousel/save.tsx
@@ -56,7 +56,7 @@ export default function Save( {
 			: false,
 		isPlaying: !! autoplay, // Initially true if autoplay is enabled
 		timerIterationId: 0,
-		selectedIndex: -1,
+		selectedIndex: 0,
 		scrollSnaps: [],
 		canScrollPrev: false,
 		canScrollNext: false,

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -285,7 +285,11 @@ store( 'rt-carousel/carousel', {
 			const { snap } = context as CarouselContext & {
 				snap?: { index?: number };
 			};
-			return context.selectedIndex === snap?.index;
+			const selectedIndex =
+				typeof context.selectedIndex === 'number' && context.selectedIndex >= 0
+					? context.selectedIndex
+					: 0;
+			return selectedIndex === snap?.index;
 		},
 		getDotLabel: () => {
 			const context = getContext<CarouselContext>();

--- a/src/blocks/carousel/view.ts
+++ b/src/blocks/carousel/view.ts
@@ -285,11 +285,14 @@ store( 'rt-carousel/carousel', {
 			const { snap } = context as CarouselContext & {
 				snap?: { index?: number };
 			};
+			if ( typeof snap?.index !== 'number' ) {
+				return false;
+			}
 			const selectedIndex =
 				typeof context.selectedIndex === 'number' && context.selectedIndex >= 0
 					? context.selectedIndex
 					: 0;
-			return selectedIndex === snap?.index;
+			return selectedIndex === snap.index;
 		},
 		getDotLabel: () => {
 			const context = getContext<CarouselContext>();


### PR DESCRIPTION
## Summary

This pull request improves accessibility and responsiveness for the carousel tab list component, making keyboard navigation clearer and ensuring better behavior on mobile devices. It also fixes logic around tab selection and focus, especially when the selected index is uninitialized.

**Accessibility improvements:**

* Updated the tab outline style in `carousel-tab-list/style.scss` to use a high-contrast color for better visibility during keyboard navigation.
* Fixed the logic in `getTabTabIndex` and related selection checks to ensure the first tab is focusable when `selectedIndex` is uninitialized or negative, improving keyboard navigation. [[1]](diffhunk://#diff-218ad861a1cd4aed0363b3c2fb1c9404b3b5b6fd4bd95b90dac4f6cddbdb8cdaL97-R106) [[2]](diffhunk://#diff-f0a39a2d87db6826b8e019e83984be685e15a484882c2a3258b46e17a564a77dR212-R218) [[3]](diffhunk://#diff-dd819e3dcf8b796c3b2861b7a0b29181bca2cde9c26272ab317f6f500eafff90L288-R292)

**Responsiveness improvements:**

* Added a media query to `carousel-tab-list/style.scss` to make the tab list horizontally scrollable on screens smaller than 1024px, preventing overflow and improving mobile usability.

**Default state fixes:**

* Changed the initial `selectedIndex` from `-1` to `0` in `save.tsx` so the first tab is selected by default, avoiding uninitialized state issues.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

Closes #176 

## What changed

- Fixes issues with tab indexing for better accessibility, user can navigate using arrow keys when user is focused on tabs
- Improved mobile and tab layout using horizontal scrolling. 

## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [ ] I have updated docs where needed
- [x] I have checked for breaking changes
