### PR TITLE
fix: mark query loop slides with the active-slide directives

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -326,23 +326,19 @@ class Plugin {
 	/**
 	 * Add the active-slide directives to Query Loop and Terms Query slides.
 	 *
-	 * The Slide block ships these directives in its saved markup, but the items rendered by
-	 * `core/post-template` or `core/term-template` carry none, so the runtime never marks them
-	 * with `is-active` or `aria-current` even though `callbacks.isSlideActive` already resolves them.
-	 * See: https://github.com/rtCamp/rt-carousel/issues/179
+	 * The Slide block ships these directives in its saved markup; query and term loop items carry
+	 * none, so the runtime never marks them. See: https://github.com/rtCamp/rt-carousel/issues/179
 	 *
 	 * @param string $block_content The carousel's rendered HTML.
 	 *
 	 * @return string The filtered HTML.
 	 */
 	public function mark_query_loop_slides( string $block_content ): string {
-		// Bail early when the carousel contains no query-driven slides.
 		if ( ! str_contains( $block_content, 'wp-block-post-template' ) && ! str_contains( $block_content, 'wp-block-term-template' ) ) {
 			return $block_content;
 		}
 
-		// WordPress 6.6, the plugin's floor, always has the HTML Processor; the unit test
-		// harness stubs only the Tag Processor, so it exercises the fallback walk.
+		// WordPress 6.6, the plugin's floor, always has the HTML Processor; the unit harness stubs only the Tag Processor.
 		$processor = class_exists( \WP_HTML_Processor::class )
 			? \WP_HTML_Processor::create_fragment( $block_content )
 			: new WP_HTML_Tag_Processor( $block_content );
@@ -360,7 +356,6 @@ class Plugin {
 				continue;
 			}
 
-			// Keep existing interactivity scopes and bindings intact.
 			if (
 				null !== $processor->get_attribute( 'data-wp-interactive' )
 				|| null !== $processor->get_attribute( 'data-wp-class--is-active' )
@@ -369,7 +364,7 @@ class Plugin {
 				continue;
 			}
 
-			// Only the carousel's own track items are slides; a loop nested inside a slide keeps its items untouched.
+			// Depth one is the carousel's own track; a loop nested inside a slide keeps its items untouched.
 			if (
 				$processor instanceof \WP_HTML_Processor
 				&& 1 !== count( array_keys( $processor->get_breadcrumbs(), 'LI', true ) )

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -44,6 +44,7 @@ class Plugin {
 		add_action( 'admin_notices', [ $this, 'legacy_plugin_notice' ] );
 		add_action( 'network_admin_notices', [ $this, 'legacy_plugin_notice' ] );
 		add_filter( 'render_block_rt-carousel/carousel', [ $this, 'handle_lazy_load_images' ], 16, 3 );
+		add_filter( 'render_block_rt-carousel/carousel', [ $this, 'mark_query_loop_slides' ] );
 	}
 
 	/**
@@ -317,6 +318,43 @@ class Plugin {
 			}
 
 			$processor->set_attribute( 'loading', 'lazy' );
+		}
+
+		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Add the active-slide directives to Query Loop and Terms Query slides.
+	 *
+	 * The Slide block ships these directives in its saved markup, but the items rendered by
+	 * `core/post-template` or `core/term-template` carry none, so the runtime never marks them
+	 * with `is-active` or `aria-current` even though `callbacks.isSlideActive` already resolves them.
+	 * See: https://github.com/rtCamp/rt-carousel/issues/179
+	 *
+	 * @param string $block_content The carousel's rendered HTML.
+	 *
+	 * @return string The filtered HTML.
+	 */
+	public function mark_query_loop_slides( string $block_content ): string {
+		// Bail early when the carousel contains no query-driven slides.
+		if ( ! str_contains( $block_content, 'wp-block-post-template' ) && ! str_contains( $block_content, 'wp-block-term-template' ) ) {
+			return $block_content;
+		}
+
+		$processor = new WP_HTML_Tag_Processor( $block_content );
+
+		while ( $processor->next_tag() ) {
+			if ( 'LI' !== $processor->get_tag() ) {
+				continue;
+			}
+
+			if ( ! $processor->has_class( 'wp-block-post' ) && ! $processor->has_class( 'wp-block-term' ) ) {
+				continue;
+			}
+
+			$processor->set_attribute( 'data-wp-interactive', 'rt-carousel/carousel' );
+			$processor->set_attribute( 'data-wp-class--is-active', 'callbacks.isSlideActive' );
+			$processor->set_attribute( 'data-wp-bind--aria-current', 'callbacks.isSlideActive' );
 		}
 
 		return $processor->get_updated_html();

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -341,7 +341,15 @@ class Plugin {
 			return $block_content;
 		}
 
-		$processor = new WP_HTML_Tag_Processor( $block_content );
+		// WordPress 6.6, the plugin's floor, always has the HTML Processor; the unit test
+		// harness stubs only the Tag Processor, so it exercises the fallback walk.
+		$processor = class_exists( \WP_HTML_Processor::class )
+			? \WP_HTML_Processor::create_fragment( $block_content )
+			: new WP_HTML_Tag_Processor( $block_content );
+
+		if ( null === $processor ) {
+			return $block_content;
+		}
 
 		while ( $processor->next_tag() ) {
 			if ( 'LI' !== $processor->get_tag() ) {
@@ -349,6 +357,23 @@ class Plugin {
 			}
 
 			if ( ! $processor->has_class( 'wp-block-post' ) && ! $processor->has_class( 'wp-block-term' ) ) {
+				continue;
+			}
+
+			// Keep existing interactivity scopes and bindings intact.
+			if (
+				null !== $processor->get_attribute( 'data-wp-interactive' )
+				|| null !== $processor->get_attribute( 'data-wp-class--is-active' )
+				|| null !== $processor->get_attribute( 'data-wp-bind--aria-current' )
+			) {
+				continue;
+			}
+
+			// Only the carousel's own track items are slides; a loop nested inside a slide keeps its items untouched.
+			if (
+				$processor instanceof \WP_HTML_Processor
+				&& 1 !== count( array_keys( $processor->get_breadcrumbs(), 'LI', true ) )
+			) {
 				continue;
 			}
 

--- a/tests/php/Unit/PluginTest.php
+++ b/tests/php/Unit/PluginTest.php
@@ -675,4 +675,24 @@ class PluginTest extends UnitTestCase {
 		$this->assertStringContainsString( '<li class="plain-item">Nope</li>', $result );
 		$this->assertStringContainsString( 'data-wp-class--is-active="callbacks.isDotActive"', $result );
 	}
+
+	/**
+	 * Test that mark_query_loop_slides keeps existing directives and scopes intact.
+	 *
+	 * @return void
+	 */
+	public function test_mark_query_loop_slides_keeps_existing_directives(): void {
+		$instance = $this->getPluginInstance();
+		$content  = '<ul class="wp-block-post-template">'
+			. '<li class="wp-block-post post-1" data-wp-interactive="my-theme/scope" data-wp-class--is-active="callbacks.myOwn">A</li>'
+			. '<li class="wp-block-post post-2">B</li>'
+			. '</ul>';
+
+		$result = $instance->mark_query_loop_slides( $content );
+
+		$this->assertStringContainsString( 'data-wp-interactive="my-theme/scope"', $result );
+		$this->assertStringContainsString( 'data-wp-class--is-active="callbacks.myOwn"', $result );
+		$this->assertSame( 1, substr_count( $result, 'data-wp-interactive="rt-carousel/carousel"' ) );
+		$this->assertSame( 1, substr_count( $result, 'data-wp-bind--aria-current="callbacks.isSlideActive"' ) );
+	}
 }

--- a/tests/php/Unit/PluginTest.php
+++ b/tests/php/Unit/PluginTest.php
@@ -626,4 +626,53 @@ class PluginTest extends UnitTestCase {
 		$this->assertStringNotContainsString( 'fetchpriority', $result );
 		$this->assertMatchesRegularExpression( '/src="a\.jpg"[^>]*loading="eager"/', $result );
 	}
+
+	/**
+	 * Test that mark_query_loop_slides returns content unmodified without a query template.
+	 *
+	 * @return void
+	 */
+	public function test_mark_query_loop_slides_returns_unmodified_without_query_template(): void {
+		$instance = $this->getPluginInstance();
+		$content  = '<div class="embla__slide"><p>Static slide</p></div>';
+
+		$result = $instance->mark_query_loop_slides( $content );
+
+		$this->assertSame( $content, $result );
+	}
+
+	/**
+	 * Test that mark_query_loop_slides adds the directives to post and term loop items.
+	 *
+	 * @return void
+	 */
+	public function test_mark_query_loop_slides_marks_post_and_term_items(): void {
+		$instance = $this->getPluginInstance();
+		$content  = '<ul class="wp-block-post-template"><li class="wp-block-post post-1">A</li><li class="wp-block-post post-2">B</li></ul>'
+			. '<ul class="wp-block-term-template"><li class="wp-block-term term-1">C</li></ul>';
+
+		$result = $instance->mark_query_loop_slides( $content );
+
+		$this->assertSame( 3, substr_count( $result, 'data-wp-interactive="rt-carousel/carousel"' ) );
+		$this->assertSame( 3, substr_count( $result, 'data-wp-class--is-active="callbacks.isSlideActive"' ) );
+		$this->assertSame( 3, substr_count( $result, 'data-wp-bind--aria-current="callbacks.isSlideActive"' ) );
+	}
+
+	/**
+	 * Test that mark_query_loop_slides leaves list items outside the query templates untouched.
+	 *
+	 * @return void
+	 */
+	public function test_mark_query_loop_slides_ignores_unrelated_markup(): void {
+		$instance = $this->getPluginInstance();
+		$content  = '<ul class="wp-block-post-template"><li class="wp-block-post post-1">A</li></ul>'
+			. '<ul class="plain-list"><li class="plain-item">Nope</li></ul>'
+			. '<button class="rt-carousel-dot" data-wp-class--is-active="callbacks.isDotActive"></button>';
+
+		$result = $instance->mark_query_loop_slides( $content );
+
+		$this->assertSame( 1, substr_count( $result, 'data-wp-bind--aria-current="callbacks.isSlideActive"' ) );
+		$this->assertStringContainsString( '<li class="plain-item">Nope</li>', $result );
+		$this->assertStringContainsString( 'data-wp-class--is-active="callbacks.isDotActive"', $result );
+	}
 }


### PR DESCRIPTION
Fixes #179

The carousel turns `core/post-template` and `core/term-template` items into slides, and `callbacks.isSlideActive` already resolves them through `CAROUSEL_SLIDE_SELECTOR` (`.wp-block-post`, `.wp-block-term`). What is missing is the markup half: the Slide block ships the directives in its save, query items ship none, so the runtime never marks them with `is-active` or `aria-current`. Dots and counter update, the slides themselves stay unmarked.

## What this does

Adds a `render_block_rt-carousel/carousel` filter that annotates the query and term loop items in the carousel's own rendered output with the exact directive set the Slide block already uses:

- `data-wp-interactive="rt-carousel/carousel"`
- `data-wp-class--is-active="callbacks.isSlideActive"`
- `data-wp-bind--aria-current="callbacks.isSlideActive"`

No JS changes, the existing callback picks the items up as is.

## Why this mechanism

- Mirrors the existing `handle_lazy_load_images` filter, same hook, same `WP_HTML_Tag_Processor` walk, so the plugin keeps one pattern for post-render markup work.
- Keeps a single active-slide mechanism (the interactivity directives) for every slide type instead of adding a parallel JS classing path. A `embla.slideNodes()` class toggle in `view.js` would also work and is smaller, happy to switch if you prefer that direction.
- Filtering our own block's output needs no opt-in markers and cannot touch markup outside the carousel. Doing this from a theme requires a class opt-in on the post template because `render_block` filters cannot see block ancestry, which is what pushed this upstream.

## Testing

- Three unit tests added to `PluginTest` in the existing DOMDocument-backed harness: bail without templates, post plus term items get all three directives, unrelated list items and the dots' own directives stay untouched.
- Ran the exact method against a live carousel render (10 post query loop, dots, counter, controls) through the real `WP_HTML_Tag_Processor` on WP 7.0.2: 10/10 items annotated, dots, counter and controls byte identical.

## Notes

- A query loop nested inside a Slide block would currently get its items annotated too, the linear tag walk has the same trade-off as the lazy-load filter's slide counting. A depth guard via `WP_HTML_Processor::get_breadcrumbs()` is possible (WP floor is 6.6) but the test harness stubs only the Tag Processor, so I kept it consistent and simple.
- Tabs mode (`useTabs`) swaps the Slide block's aria bindings for tabpanel ones; query slides get the standard set here, tabs-specific bindings for query slides would be a follow-up.
