### PR TITLE
Version bump 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.1.0](https://github.com/rtCamp/rt-carousel/compare/2.0.3...2.1.0) - 2026-08-03
+
+### Features
+* Add fade transition option. [#159](https://github.com/rtCamp/rt-carousel/pull/159)
+* Add Embla Auto Scroll plugin support with editor controls.[#152](https://github.com/rtCamp/rt-carousel/pull/152)
+* Add LazyLoadImages toggle to Carousel block with per-slide override option.[#100](https://github.com/rtCamp/rt-carousel/pull/100)
+* Added carousel tabs mode.[#167](https://github.com/rtCamp/rt-carousel/pull/167)
+
+### Maintaince
+* Add logic to reset autoplay and autoscroll on carousel interaction.[#164](https://github.com/rtCamp/rt-carousel/pull/164)
+* Fixes issues with tab not able to edit tab title and also removes tab lists when tabs are toggled off.[#173](https://github.com/rtCamp/rt-carousel/pull/173)
+* Mark query loop slides with the active-slide directives.[#180](https://github.com/rtCamp/rt-carousel/pull/180)
+* Improve Auto Scroll UX and enforce compatible transition settings.[#165](https://github.com/rtCamp/rt-carousel/pull/165)
+* Add logic to reset autoplay and autoscroll on carousel interaction.[#164](https://github.com/rtCamp/rt-carousel/pull/164)
+
 ## [2.0.3](https://github.com/rtCamp/rt-carousel/compare/2.0.2...2.0.3) (2026-06-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@
 * Add LazyLoadImages toggle to Carousel block with per-slide override option.[#100](https://github.com/rtCamp/rt-carousel/pull/100)
 * Added carousel tabs mode.[#167](https://github.com/rtCamp/rt-carousel/pull/167)
 
-### Maintaince
+### Maintenance
 * Add logic to reset autoplay and autoscroll on carousel interaction.[#164](https://github.com/rtCamp/rt-carousel/pull/164)
 * Fixes issues with tab not able to edit tab title and also removes tab lists when tabs are toggled off.[#173](https://github.com/rtCamp/rt-carousel/pull/173)
 * Mark query loop slides with the active-slide directives.[#180](https://github.com/rtCamp/rt-carousel/pull/180)
 * Improve Auto Scroll UX and enforce compatible transition settings.[#165](https://github.com/rtCamp/rt-carousel/pull/165)
-* Add logic to reset autoplay and autoscroll on carousel interaction.[#164](https://github.com/rtCamp/rt-carousel/pull/164)
 
 ## [2.0.3](https://github.com/rtCamp/rt-carousel/compare/2.0.2...2.0.3) (2026-06-24)
 

--- a/languages/rt-carousel.pot
+++ b/languages/rt-carousel.pot
@@ -2,22 +2,22 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: rtCarousel 2.0.3\n"
+"Project-Id-Version: rtCarousel 2.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/rtCamp/rt-carousel/issues\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-25T06:24:07+00:00\n"
+"POT-Creation-Date: 2026-08-03T09:40:59+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.10.0\n"
+"X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: rt-carousel\n"
 
 #. Plugin Name of the plugin
 #: rt-carousel.php
-#: inc/Plugin.php:118
-#: inc/Plugin.php:159
+#: inc/Plugin.php:122
+#: inc/Plugin.php:164
 msgid "rtCarousel"
 msgstr ""
 
@@ -45,323 +45,430 @@ msgstr ""
 msgid "rtCarousel: The Composer autoloader was not found. If you installed the plugin from the GitHub source code, make sure to run `composer install`."
 msgstr ""
 
-#: inc/Plugin.php:99
+#: inc/Plugin.php:103
 msgid "The \"Carousel Kit\" plugin is still active. rtCarousel is its replacement — please deactivate Carousel Kit."
 msgstr ""
 
-#: inc/Plugin.php:101
+#: inc/Plugin.php:105
 msgid "Deactivate Carousel Kit"
 msgstr ""
 
-#: inc/Plugin.php:160
+#: inc/Plugin.php:165
 msgid "Pre-configured carousel patterns for various use cases."
 msgstr ""
 
-#: build/blocks/carousel/controls/index.js:137
-#: build/blocks/carousel/controls/index.js:212
+#: build/blocks/carousel/carousel-tab-list/index.js:1
+msgid "Active Tab"
+msgstr ""
+
+#: build/blocks/carousel/carousel-tab-list/index.js:1
+msgid "Background"
+msgstr ""
+
+#: build/blocks/carousel/carousel-tab-list/index.js:1
+msgid "Text"
+msgstr ""
+
+#: build/blocks/carousel/carousel-tab-list/index.js:1
+msgid "Inactive Tab"
+msgstr ""
+
+#: build/blocks/carousel/carousel-tab-list/index.js:1
+#: build/blocks/carousel/carousel-tab-list/index.js:2
+msgid "Carousel tabs"
+msgstr ""
+
+#: build/blocks/carousel/carousel-tab-list/index.js:2
+msgid "Tab %d"
+msgstr ""
+
+#: build/blocks/carousel/controls/index.js:1
 msgid "Previous Slide"
 msgstr ""
 
-#: build/blocks/carousel/controls/index.js:147
-#: build/blocks/carousel/controls/index.js:219
+#: build/blocks/carousel/controls/index.js:1
 msgid "Next Slide"
 msgstr ""
 
 #. translators: 1: current slide number, 2: total slide count.
-#: build/blocks/carousel/counter/index.js:51
+#: build/blocks/carousel/counter/index.js:2
 msgid "Slide %1$d of %2$d"
 msgstr ""
 
-#: build/blocks/carousel/counter/index.js:122
+#: build/blocks/carousel/counter/index.js:2
 msgid "Carousel counter"
 msgstr ""
 
 #. translators: %d: slide number
-#: build/blocks/carousel/dots/index.js:123
-#: build/blocks/carousel/index.js:302
-#: build/blocks/carousel/index.js:1028
+#: build/blocks/carousel/dots/index.js:2
+#: build/blocks/carousel/index.js:3
+#: build/blocks/carousel/index.js:9
+#: build/blocks/carousel/index.js:11
 msgid "Go to slide %d"
 msgstr ""
 
-#: build/blocks/carousel/index.js:226
-msgid "Back"
-msgstr ""
-
-#: build/blocks/carousel/index.js:637
-msgid "Carousel Settings"
-msgstr ""
-
-#: build/blocks/carousel/index.js:639
-msgid "Loop"
-msgstr ""
-
-#: build/blocks/carousel/index.js:644
-msgid "Enables infinite scrolling of slides."
-msgstr ""
-
-#: build/blocks/carousel/index.js:646
-msgid "Free Drag"
-msgstr ""
-
-#: build/blocks/carousel/index.js:651
-msgid "Enables momentum scrolling."
-msgstr ""
-
-#: build/blocks/carousel/index.js:653
-msgid "Alignment"
-msgstr ""
-
-#: build/blocks/carousel/index.js:656
-msgid "Start"
-msgstr ""
-
-#: build/blocks/carousel/index.js:659
-msgid "Center"
-msgstr ""
-
-#: build/blocks/carousel/index.js:662
-msgid "End"
-msgstr ""
-
-#: build/blocks/carousel/index.js:669
-msgid "Contain Scroll"
-msgstr ""
-
-#: build/blocks/carousel/index.js:672
-msgid "Trim Snaps"
-msgstr ""
-
-#: build/blocks/carousel/index.js:675
-msgid "Keep Snaps"
-msgstr ""
-
-#: build/blocks/carousel/index.js:678
-msgid "None"
-msgstr ""
-
-#: build/blocks/carousel/index.js:684
-msgid "Prevents excess scrolling at the beginning or end."
-msgstr ""
-
-#: build/blocks/carousel/index.js:686
-msgid "Scroll Auto"
-msgstr ""
-
-#: build/blocks/carousel/index.js:691
-msgid "Scrolls the number of slides currently visible in the viewport."
-msgstr ""
-
-#: build/blocks/carousel/index.js:693
-msgid "Slides to Scroll"
-msgstr ""
-
-#: build/blocks/carousel/index.js:701
-msgid "Direction"
-msgstr ""
-
-#: build/blocks/carousel/index.js:704
-msgid "Left to Right (LTR)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:707
-msgid "Right to Left (RTL)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:713
-msgid "Choose content direction. RTL is typically used for Arabic, Hebrew, and other right-to-left languages."
-msgstr ""
-
-#: build/blocks/carousel/index.js:715
-msgid "Orientation"
-msgstr ""
-
-#: build/blocks/carousel/index.js:718
-msgid "Horizontal"
-msgstr ""
-
-#: build/blocks/carousel/index.js:721
-msgid "Vertical"
-msgstr ""
-
-#: build/blocks/carousel/index.js:728
-msgid "Height"
-msgstr ""
-
-#: build/blocks/carousel/index.js:733
-msgid "Set a fixed height for vertical carousel (e.g., 400px)."
-msgstr ""
-
-#: build/blocks/carousel/index.js:736
-msgid "Autoplay Options"
-msgstr ""
-
-#: build/blocks/carousel/index.js:739
-msgid "Enable Autoplay"
-msgstr ""
-
-#: build/blocks/carousel/index.js:746
-msgid "Delay (ms)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:755
-msgid "Stop on Interaction"
-msgstr ""
-
-#: build/blocks/carousel/index.js:760
-msgid "Stop autoplay when user interacts with carousel."
-msgstr ""
-
-#: build/blocks/carousel/index.js:762
-msgid "Stop on Mouse Enter"
-msgstr ""
-
-#: build/blocks/carousel/index.js:767
-msgid "Stop autoplay when mouse hovers over carousel."
-msgstr ""
-
-#: build/blocks/carousel/index.js:773
-msgid "ARIA Label"
-msgstr ""
-
-#: build/blocks/carousel/index.js:778
-msgid "Provide a descriptive label for screen readers (e.g., 'Featured Products')."
-msgstr ""
-
-#: build/blocks/carousel/index.js:781
-msgid "Use this to allow only certain blocks in the slide. If empty, all blocks will be allowed."
-msgstr ""
-
-#: build/blocks/carousel/index.js:784
-msgid "Allowed Slide Blocks"
-msgstr ""
-
-#: build/blocks/carousel/index.js:797
-msgid "Layout"
-msgstr ""
-
-#: build/blocks/carousel/index.js:799
-msgid "Slide Gap (px)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:819
-msgid "Carousel"
-msgstr ""
-
-#: build/blocks/carousel/index.js:820
-msgid "How many slides would you like to start with?"
-msgstr ""
-
-#: build/blocks/carousel/index.js:820
-msgid "Choose a slide template:"
-msgstr ""
-
-#: build/blocks/carousel/index.js:830
-msgid "1 Slide"
-msgstr ""
-
-#: build/blocks/carousel/index.js:830
-msgid "Slides"
-msgstr ""
-
-#: build/blocks/carousel/index.js:836
-msgid "Skip"
-msgstr ""
-
-#: build/blocks/carousel/index.js:855
-#: build/blocks/carousel/viewport/index.js:2093
-#: build/blocks/carousel/viewport/index.js:2244
-#: build/blocks/carousel/viewport/index.js:2254
-msgid "Add Slide"
-msgstr ""
-
-#: build/blocks/carousel/index.js:947
-msgid "Default (100%)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:951
-msgid "2 Columns (50%)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:954
-msgid "3 Columns (33%)"
-msgstr ""
-
-#: build/blocks/carousel/index.js:957
-msgid "4 Columns (25%)"
-msgstr ""
-
-#. translators: {{currentSlide}}: current slide number, {{totalSlides}}: total slide count.
-#: build/blocks/carousel/index.js:1030
-#: build/blocks/carousel/index.js:1034
-msgid "Slide {{currentSlide}} of {{totalSlides}}"
-msgstr ""
-
-#: build/blocks/carousel/index.js:1123
+#: build/blocks/carousel/index.js:1
 msgid "Text Slides"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1124
+#: build/blocks/carousel/index.js:1
 msgid "Slides starting with a paragraph you can replace or extend."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1130
+#: build/blocks/carousel/index.js:1
 msgid "Image Slides"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1131
+#: build/blocks/carousel/index.js:1
 msgid "Slides prefilled with an image block."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1137
+#: build/blocks/carousel/index.js:1
 msgid "Image + Heading + Text + CTA"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1138
+#: build/blocks/carousel/index.js:1
 msgid "Marketing slider with heading, paragraph, and button."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1142
+#: build/blocks/carousel/index.js:1
 msgid "Slide Heading"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1144
+#: build/blocks/carousel/index.js:1
 msgid "Slide description text…"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1149
+#: build/blocks/carousel/index.js:1
 msgid "Image + Caption"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1150
+#: build/blocks/carousel/index.js:1
 msgid "Image with supporting text below."
 msgstr ""
 
-#: build/blocks/carousel/index.js:1153
+#: build/blocks/carousel/index.js:1
 msgid "Caption text…"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1158
+#: build/blocks/carousel/index.js:1
 msgid "Query Loop Slides"
 msgstr ""
 
-#: build/blocks/carousel/index.js:1159
+#: build/blocks/carousel/index.js:1
 msgid "Dynamically generate slides from posts."
 msgstr ""
 
-#: build/blocks/carousel/progress/index.js:95
-#: build/blocks/carousel/progress/index.js:161
+#: build/blocks/carousel/index.js:1
+msgid "Back"
+msgstr ""
+
+#. translators: {{currentSlide}}: current slide number, {{totalSlides}}: total slide count.
+#: build/blocks/carousel/index.js:5
+#: build/blocks/carousel/index.js:7
+#: build/blocks/carousel/index.js:13
+#: build/blocks/carousel/index.js:15
+msgid "Slide {{currentSlide}} of {{totalSlides}}"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Tab Settings"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Carousel Settings"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Use as Tabs"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Converts the carousel into an accessible tab widget."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Transition"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Slide"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Fade"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Auto Scroll does not support transitions."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Choose how slides transition: sliding horizontally or cross-fading."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Loop"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Loop is required for backward auto scroll."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Enables infinite scrolling of slides."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Free Drag"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Enables momentum scrolling."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Lazy Load Images"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Load images only when they enter the viewport."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Alignment"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Start"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Center"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "End"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Contain Scroll"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Trim Snaps"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Keep Snaps"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "None"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Prevents excess scrolling at the beginning or end."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Scroll Auto"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Scrolls the number of slides currently visible in the viewport."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Slides to Scroll"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Direction"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Left to Right (LTR)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Right to Left (RTL)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Choose content direction. RTL is typically used for Arabic, Hebrew, and other right-to-left languages."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Orientation"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Horizontal"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Vertical"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Height"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Set a fixed height for vertical carousel (e.g., 400px)."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Autoplay Options"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Enable Autoplay"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Delay (ms)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop on Interaction"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop autoplay when user interacts with carousel."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop on Mouse Enter"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop autoplay when mouse hovers over carousel."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Auto Scroll"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Enable Auto Scroll"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Speed"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Forward"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Backward"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Start Delay (ms)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop auto scroll when user interacts with carousel."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Stop auto scroll when mouse hovers over carousel."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "ARIA Label"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Provide a descriptive label for screen readers (e.g., 'Featured Products')."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Use this to allow only certain blocks in the slide. If empty, all blocks will be allowed."
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Allowed Slide Blocks"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Layout"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Slide Gap (px)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Carousel"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "How many slides would you like to start with?"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Choose a slide template:"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "1 Slide"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Slides"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+msgid "Skip"
+msgstr ""
+
+#: build/blocks/carousel/index.js:9
+#: build/blocks/carousel/viewport/index.js:1
+msgid "Add Slide"
+msgstr ""
+
+#: build/blocks/carousel/index.js:15
+msgid "Tabs"
+msgstr ""
+
+#: build/blocks/carousel/index.js:15
+msgid "Default (100%)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:15
+msgid "2 Columns (50%)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:15
+msgid "3 Columns (33%)"
+msgstr ""
+
+#: build/blocks/carousel/index.js:15
+msgid "4 Columns (25%)"
+msgstr ""
+
+#: build/blocks/carousel/progress/index.js:1
 msgid "Carousel progress"
 msgstr ""
 
-#: build/blocks/carousel/viewport/index.js:2097
+#: build/blocks/carousel/slide/index.js:1
+msgid "Tab Panel"
+msgstr ""
+
+#: build/blocks/carousel/viewport/index.js:1
 msgid "Add Query Loop"
 msgstr ""
 
-#: build/blocks/carousel/viewport/index.js:2101
+#: build/blocks/carousel/viewport/index.js:1
 msgid "Add Terms Query"
 msgstr ""
 
-#: build/blocks/carousel/viewport/index.js:2249
+#: build/blocks/carousel/viewport/index.js:1
 msgid "Viewport Actions"
 msgstr ""
 
@@ -375,6 +482,18 @@ msgstr ""
 #: src/blocks/carousel/block.json
 msgctxt "block description"
 msgid "Carousel container using Embla and Interactivity API."
+msgstr ""
+
+#: build/blocks/carousel/carousel-tab-list/block.json
+#: src/blocks/carousel/carousel-tab-list/block.json
+msgctxt "block title"
+msgid "Tab List"
+msgstr ""
+
+#: build/blocks/carousel/carousel-tab-list/block.json
+#: src/blocks/carousel/carousel-tab-list/block.json
+msgctxt "block description"
+msgid "Tab navigation for a carousel in tabs mode."
 msgstr ""
 
 #: build/blocks/carousel/controls/block.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rt-carousel",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rt-carousel",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "dependencies": {
         "@wordpress/babel-preset-default": "8.38.0",
         "@wordpress/block-editor": "^15.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rt-carousel",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Carousel block using Embla and WordPress Interactivity API",
   "author": "rtCamp",
   "private": true,

--- a/readme.txt
+++ b/readme.txt
@@ -86,14 +86,14 @@ rtCarousel is the successor to Carousel Kit. Simply install and activate rtCarou
 == Changelog ==
 
 = 2.1.0 =
-* New : add fade transition option.
-* New : add Embla Auto Scroll plugin support with editor controls.
-* New : Add LazyLoadImages toggle to Carousel block with per-slide override option.
-* New : Added carousel tabs mode.
-* Tweak : Add logic to reset autoplay and autoscroll on carousel interaction.
-* Tweak : Fixes issues with tab not able to edit tab title and also removes tab lists when tabs are toggled off.
-* Tweak : mark query loop slides with the active-slide directives.
-* Tweak : improve Auto Scroll UX and enforce compatible transition settings.
+* New: add fade transition option.
+* New: add Embla Auto Scroll plugin support with editor controls.
+* New: Add LazyLoadImages toggle to Carousel block with per-slide override option.
+* New: Added carousel tabs mode.
+* Tweak: Add logic to reset autoplay and autoscroll on carousel interaction.
+* Tweak: Fixes issues with tab not able to edit tab title and also removes tab lists when tabs are toggled off.
+* Tweak: Mark query loop slides with the active-slide directives.
+* Tweak: Improve Auto Scroll UX and enforce compatible transition settings.
 * Tweak: Add logic to reset autoplay and autoscroll on carousel interaction.
 
 = 2.0.3 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: carousel, slider, block, interactivity-api, embla
 Requires at least: 6.6
 Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: 2.0.3
+Stable tag: 2.1.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -84,6 +84,17 @@ rtCarousel is the successor to Carousel Kit. Simply install and activate rtCarou
 1. Carousel block in the editor with multiple slides
 
 == Changelog ==
+
+= 2.1.0 =
+* New : add fade transition option.
+* New : add Embla Auto Scroll plugin support with editor controls.
+* New : Add LazyLoadImages toggle to Carousel block with per-slide override option.
+* New : Added carousel tabs mode.
+* Tweak : Add logic to reset autoplay and autoscroll on carousel interaction.
+* Tweak : Fixes issues with tab not able to edit tab title and also removes tab lists when tabs are toggled off.
+* Tweak : mark query loop slides with the active-slide directives.
+* Tweak : improve Auto Scroll UX and enforce compatible transition settings.
+* Tweak: Add logic to reset autoplay and autoscroll on carousel interaction.
 
 = 2.0.3 =
 * Tweak: Update plugin display name to a more descriptive title for discoverability.

--- a/rt-carousel.php
+++ b/rt-carousel.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * License:     GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Version:     2.0.3
+ * Version:     2.1.0
  * Text Domain: rt-carousel
  *
  * @package rt-carousel


### PR DESCRIPTION

## Summary

This PR will merge the develop branch into the main branch to release version 2.1.0

### Features
* Add fade transition option. [#159](https://github.com/rtCamp/rt-carousel/pull/159)
* Add Embla Auto Scroll plugin support with editor controls.[#152](https://github.com/rtCamp/rt-carousel/pull/152)
* Add LazyLoadImages toggle to Carousel block with per-slide override option.[#100](https://github.com/rtCamp/rt-carousel/pull/100)
* Added carousel tabs mode.[#167](https://github.com/rtCamp/rt-carousel/pull/167)

### Maintaince
* Add logic to reset autoplay and autoscroll on carousel interaction.[#164](https://github.com/rtCamp/rt-carousel/pull/164)
* Fixes issues with tab not able to edit tab title and also removes tab lists when tabs are toggled off.[#173](https://github.com/rtCamp/rt-carousel/pull/173)
* Mark query loop slides with the active-slide directives.[#180](https://github.com/rtCamp/rt-carousel/pull/180)
* Improve Auto Scroll UX and enforce compatible transition settings.[#165](https://github.com/rtCamp/rt-carousel/pull/165)
* Add logic to reset autoplay and autoscroll on carousel interaction.[#164](https://github.com/rtCamp/rt-carousel/pull/164)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement/refactor
- [x] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

N/A


## Breaking changes

Does this introduce a breaking change? If yes, describe the impact and migration path below.

- [ ] Yes — migration path: <!-- describe here -->
- [x] No

## Testing

Describe how this was tested.

- [ ] Unit tests
- [x] Manual testing
- [ ] Cross-browser testing (if UI changes)

Test details:

## Screenshots / recordings

If applicable, add screenshots or short recordings.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added/updated tests where needed
- [x] I have updated docs where needed
- [x] I have checked for breaking changes
