### PR TITLE
feat: add arrow position options (below/overlay/outside) to Controls block

### DIFF
--- a/src/blocks/carousel/controls/__tests__/edit.test.tsx
+++ b/src/blocks/carousel/controls/__tests__/edit.test.tsx
@@ -4,82 +4,138 @@
 
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { SelectControl } from '@wordpress/components';
 import Edit from '../edit';
 import { EditorCarouselContext } from '../../editor-context';
+import type { CarouselControlsAttributes } from '../../types';
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: jest.fn( ( props = {} ) => ( {
 		...props,
 		ref: jest.fn(),
 	} ) ),
+	InspectorControls: ( { children }: { children: ReactNode } ) => (
+		<div data-testid="inspector-controls">{ children }</div>
+	),
 } ) );
 
 jest.mock( '@wordpress/compose', () => ( {
 	useMergeRefs: jest.fn( () => jest.fn() ),
 } ) );
 
+const baseContext = {
+	emblaApi: undefined,
+	setEmblaApi: jest.fn(),
+	canScrollPrev: false,
+	canScrollNext: false,
+	setCanScrollPrev: jest.fn(),
+	setCanScrollNext: jest.fn(),
+	scrollProgress: 0,
+	setScrollProgress: jest.fn(),
+	selectedIndex: 0,
+	setSelectedIndex: jest.fn(),
+	scrollSnaps: [],
+	slideCount: 2,
+	carouselOptions: { autoScroll: false },
+};
+
+function renderEdit(
+	attributes: CarouselControlsAttributes,
+	setAttributes = jest.fn(),
+	contextOverrides = {},
+) {
+	return render(
+		<EditorCarouselContext.Provider
+			value={ { ...baseContext, ...contextOverrides } }
+		>
+			<Edit attributes={ attributes } setAttributes={ setAttributes } />
+		</EditorCarouselContext.Provider>,
+	);
+}
+
 describe( 'Carousel Controls Edit', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	it( 'disables buttons when autoScroll is false and canScrollPrev/canScrollNext are false', () => {
-		render(
-			<EditorCarouselContext.Provider
-				value={ {
-					emblaApi: undefined,
-					setEmblaApi: jest.fn(),
-					canScrollPrev: false,
-					canScrollNext: false,
-					setCanScrollPrev: jest.fn(),
-					setCanScrollNext: jest.fn(),
-					scrollProgress: 0,
-					setScrollProgress: jest.fn(),
-					selectedIndex: 0,
-					setSelectedIndex: jest.fn(),
-					scrollSnaps: [],
-					slideCount: 2,
-					carouselOptions: {
-						autoScroll: false,
-					},
-				} }
-			>
-				<Edit />
-			</EditorCarouselContext.Provider>,
-		);
+		renderEdit( { position: 'below' } );
 
-		const prevBtn = screen.getByRole( 'button', { name: 'Previous Slide' } );
-		const nextBtn = screen.getByRole( 'button', { name: 'Next Slide' } );
-
-		expect( prevBtn ).toBeDisabled();
-		expect( nextBtn ).toBeDisabled();
+		expect(
+			screen.getByRole( 'button', { name: 'Previous Slide' } ),
+		).toBeDisabled();
+		expect(
+			screen.getByRole( 'button', { name: 'Next Slide' } ),
+		).toBeDisabled();
 	} );
 
 	it( 'keeps prev/next buttons enabled when autoScroll is true even if canScrollPrev/canScrollNext are false', () => {
-		render(
-			<EditorCarouselContext.Provider
-				value={ {
-					emblaApi: undefined,
-					setEmblaApi: jest.fn(),
-					canScrollPrev: false,
-					canScrollNext: false,
-					setCanScrollPrev: jest.fn(),
-					setCanScrollNext: jest.fn(),
-					scrollProgress: 0,
-					setScrollProgress: jest.fn(),
-					selectedIndex: 0,
-					setSelectedIndex: jest.fn(),
-					scrollSnaps: [],
-					slideCount: 2,
-					carouselOptions: {
-						autoScroll: true,
-					},
-				} }
-			>
-				<Edit />
-			</EditorCarouselContext.Provider>,
+		renderEdit( { position: 'below' }, jest.fn(), {
+			carouselOptions: { autoScroll: true },
+		} );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Previous Slide' } ),
+		).not.toBeDisabled();
+		expect(
+			screen.getByRole( 'button', { name: 'Next Slide' } ),
+		).not.toBeDisabled();
+	} );
+
+	it( 'uses only the base class for the default "below" position (back-compat)', () => {
+		const { container } = renderEdit( { position: 'below' } );
+		const wrapper = container.querySelector( '.rt-carousel-controls' );
+
+		expect( wrapper ).toBeInTheDocument();
+		expect( wrapper ).not.toHaveClass( 'is-position-overlay' );
+		expect( wrapper ).not.toHaveClass( 'is-position-outside' );
+	} );
+
+	it( 'applies the overlay modifier class when position is "overlay"', () => {
+		const { container } = renderEdit( { position: 'overlay' } );
+
+		expect( container.querySelector( '.rt-carousel-controls' ) ).toHaveClass(
+			'is-position-overlay',
 		);
+	} );
 
-		const prevBtn = screen.getByRole( 'button', { name: 'Previous Slide' } );
-		const nextBtn = screen.getByRole( 'button', { name: 'Next Slide' } );
+	it( 'renders the Position select and updates the attribute on change', () => {
+		const setAttributes = jest.fn();
+		renderEdit( { position: 'below' }, setAttributes );
 
-		expect( prevBtn ).not.toBeDisabled();
-		expect( nextBtn ).not.toBeDisabled();
+		const positionCall = (
+			SelectControl as unknown as jest.Mock
+		).mock.calls.find( ( call ) => call[ 0 ].label === 'Position' );
+
+		expect( positionCall ).toBeTruthy();
+
+		positionCall[ 0 ].onChange( 'outside' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { position: 'outside' } );
+	} );
+
+	it( 'applies the outside modifier class when position is "outside"', () => {
+		const { container } = renderEdit( { position: 'outside' } );
+
+		expect( container.querySelector( '.rt-carousel-controls' ) ).toHaveClass(
+			'is-position-outside',
+		);
+	} );
+
+	it( 'shows the placement hint only for non-below positions', () => {
+		renderEdit( { position: 'below' } );
+		const belowCall = (
+			SelectControl as unknown as jest.Mock
+		).mock.calls.find( ( call ) => call[ 0 ].label === 'Position' );
+		expect( belowCall[ 0 ].help ).toBeUndefined();
+
+		jest.clearAllMocks();
+
+		renderEdit( { position: 'overlay' } );
+		const overlayCall = (
+			SelectControl as unknown as jest.Mock
+		).mock.calls.find( ( call ) => call[ 0 ].label === 'Position' );
+		expect( overlayCall[ 0 ].help ).toBeTruthy();
 	} );
 } );

--- a/src/blocks/carousel/controls/__tests__/get-position-class.test.ts
+++ b/src/blocks/carousel/controls/__tests__/get-position-class.test.ts
@@ -1,0 +1,23 @@
+import { getPositionClassName } from '../get-position-class';
+
+describe( 'getPositionClassName', () => {
+	it( 'returns only the base class for the default "below" position', () => {
+		expect( getPositionClassName( 'below' ) ).toBe( 'rt-carousel-controls' );
+	} );
+
+	it( 'returns the base class with no modifier when position is undefined (back-compat)', () => {
+		expect( getPositionClassName( undefined ) ).toBe( 'rt-carousel-controls' );
+	} );
+
+	it( 'adds the overlay modifier for the "overlay" position', () => {
+		expect( getPositionClassName( 'overlay' ) ).toBe(
+			'rt-carousel-controls is-position-overlay',
+		);
+	} );
+
+	it( 'adds the outside modifier for the "outside" position', () => {
+		expect( getPositionClassName( 'outside' ) ).toBe(
+			'rt-carousel-controls is-position-outside',
+		);
+	} );
+} );

--- a/src/blocks/carousel/controls/block.json
+++ b/src/blocks/carousel/controls/block.json
@@ -11,7 +11,12 @@
 	],
 	"description": "Navigation buttons for the carousel.",
 	"textdomain": "rt-carousel",
-	"attributes": {},
+	"attributes": {
+		"position": {
+			"type": "string",
+			"default": "below"
+		}
+	},
 	"supports": {
 		"interactivity": true
 	},

--- a/src/blocks/carousel/controls/edit.tsx
+++ b/src/blocks/carousel/controls/edit.tsx
@@ -1,14 +1,27 @@
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext, useRef } from '@wordpress/element';
 import { EditorCarouselContext } from '../editor-context';
 import { NextIcon, PreviousIcon } from './components/icons';
+import { getPositionClassName } from './get-position-class';
+import type {
+	CarouselControlsAttributes,
+	CarouselControlsPosition,
+} from '../types';
 import type { EmblaCarouselType } from 'embla-carousel';
 import { useMergeRefs } from '@wordpress/compose';
 
 const EMBLA_KEY = Symbol.for( 'carousel-system.carousel' );
 
-export default function Edit() {
+export default function Edit( {
+	attributes,
+	setAttributes,
+}: {
+	attributes: CarouselControlsAttributes;
+	setAttributes: ( attributes: Partial<CarouselControlsAttributes> ) => void;
+} ) {
+	const { position } = attributes;
 	const {
 		emblaApi: contextApi,
 		canScrollPrev,
@@ -18,7 +31,7 @@ export default function Edit() {
 	const ref = useRef<HTMLDivElement>( null );
 
 	const blockProps = useBlockProps( {
-		className: 'rt-carousel-controls',
+		className: getPositionClassName( position ),
 	} );
 
 	const mergedRef = useMergeRefs( [ blockProps.ref, ref ] );
@@ -51,31 +64,61 @@ export default function Edit() {
 	};
 
 	return (
-		<div { ...blockProps } ref={ mergedRef }>
-			<button
-				className="rt-carousel-controls__btn rt-carousel-controls__btn--prev"
-				onClick={ ( e ) => {
-					e.stopPropagation();
-					handleScroll( 'prev' );
-				} }
-				type="button"
-				disabled={ ! carouselOptions?.autoScroll && ! canScrollPrev }
-				aria-label={ __( 'Previous Slide', 'rt-carousel' ) }
-			>
-				<PreviousIcon />
-			</button>
-			<button
-				className="rt-carousel-controls__btn rt-carousel-controls__btn--next"
-				onClick={ ( e ) => {
-					e.stopPropagation();
-					handleScroll( 'next' );
-				} }
-				type="button"
-				disabled={ ! carouselOptions?.autoScroll && ! canScrollNext }
-				aria-label={ __( 'Next Slide', 'rt-carousel' ) }
-			>
-				<NextIcon />
-			</button>
-		</div>
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'rt-carousel' ) }>
+					<SelectControl
+						label={ __( 'Position', 'rt-carousel' ) }
+						value={ position }
+						options={ [
+							{ label: __( 'Below', 'rt-carousel' ), value: 'below' },
+							{ label: __( 'Overlay', 'rt-carousel' ), value: 'overlay' },
+							{ label: __( 'Outside', 'rt-carousel' ), value: 'outside' },
+						] }
+						onChange={ ( value ) =>
+							setAttributes( {
+								position: value as CarouselControlsPosition,
+							} )
+						}
+						help={
+							position !== 'below'
+								? __(
+									'For best results, place the Controls block directly inside the carousel (not inside a Group).',
+									'rt-carousel',
+								)
+								: undefined
+						}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps } ref={ mergedRef }>
+				<button
+					className="rt-carousel-controls__btn rt-carousel-controls__btn--prev"
+					onClick={ ( e ) => {
+						e.stopPropagation();
+						handleScroll( 'prev' );
+					} }
+					type="button"
+					disabled={ ! carouselOptions?.autoScroll && ! canScrollPrev }
+					aria-label={ __( 'Previous Slide', 'rt-carousel' ) }
+				>
+					<PreviousIcon />
+				</button>
+				<button
+					className="rt-carousel-controls__btn rt-carousel-controls__btn--next"
+					onClick={ ( e ) => {
+						e.stopPropagation();
+						handleScroll( 'next' );
+					} }
+					type="button"
+					disabled={ ! carouselOptions?.autoScroll && ! canScrollNext }
+					aria-label={ __( 'Next Slide', 'rt-carousel' ) }
+				>
+					<NextIcon />
+				</button>
+			</div>
+		</>
 	);
 }

--- a/src/blocks/carousel/controls/get-position-class.ts
+++ b/src/blocks/carousel/controls/get-position-class.ts
@@ -1,0 +1,23 @@
+import type { CarouselControlsPosition } from '../types';
+
+const BASE_CLASS = 'rt-carousel-controls';
+
+/**
+ * Build the Controls wrapper class list for a given arrow position.
+ *
+ * The default `below` position returns ONLY the base class so that existing
+ * saved blocks (which serialize no `position` attribute) keep byte-identical
+ * markup and stay valid. Overlay/outside add a single modifier class that the
+ * stylesheet keys off.
+ *
+ * @param {CarouselControlsPosition} [position] Selected arrow position; falsy/`below` yields the base class.
+ * @return {string} Space-separated class string for the Controls wrapper.
+ */
+export function getPositionClassName(
+	position?: CarouselControlsPosition,
+): string {
+	if ( position === 'overlay' || position === 'outside' ) {
+		return `${ BASE_CLASS } is-position-${ position }`;
+	}
+	return BASE_CLASS;
+}

--- a/src/blocks/carousel/controls/save.tsx
+++ b/src/blocks/carousel/controls/save.tsx
@@ -1,10 +1,18 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { NextIcon, PreviousIcon } from './components/icons';
+import { getPositionClassName } from './get-position-class';
+import type { CarouselControlsAttributes } from '../types';
 
-export default function Save() {
+export default function Save( {
+	attributes,
+}: {
+	attributes: CarouselControlsAttributes;
+} ) {
+	const { position } = attributes;
+
 	const blockProps = useBlockProps.save( {
-		className: 'rt-carousel-controls',
+		className: getPositionClassName( position ),
 	} );
 
 	return (

--- a/src/blocks/carousel/controls/style.scss
+++ b/src/blocks/carousel/controls/style.scss
@@ -64,6 +64,7 @@
 .rt-carousel:not([data-axis="y"]) .rt-carousel-controls.is-position-outside {
 	position: absolute;
 	inset: 0;
+	z-index: var(--rt-carousel-control-z, 1);
 	display: flex;
 	align-items: center;
 	justify-content: space-between;

--- a/src/blocks/carousel/controls/style.scss
+++ b/src/blocks/carousel/controls/style.scss
@@ -47,3 +47,53 @@
 .rt-carousel[data-axis="y"][dir="rtl"] .rt-carousel-controls__btn svg {
 	transform: rotate(-90deg); // or 270deg
 }
+
+/**
+ * Arrow position options (issue #143).
+ *
+ * `below` (default) uses the base flex row above — no overrides here.
+ * `overlay` floats the arrows over the slide edges; `outside` reserves side
+ * gutters so the arrows flank the slides. Both are horizontal-only: vertical
+ * carousels keep the stacked "below" behavior.
+ */
+
+// Shared overlay/outside behavior: absolutely position within .rt-carousel
+// (already position: relative), split the buttons to the edges, and let clicks
+// pass through the gaps to the slides underneath.
+.rt-carousel:not([data-axis="y"]) .rt-carousel-controls.is-position-overlay,
+.rt-carousel:not([data-axis="y"]) .rt-carousel-controls.is-position-outside {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	pointer-events: none;
+}
+
+.rt-carousel-controls.is-position-overlay .rt-carousel-controls__btn,
+.rt-carousel-controls.is-position-outside .rt-carousel-controls__btn {
+	pointer-events: auto;
+}
+
+// Overlay: arrows sit just inside the slide edges.
+.rt-carousel:not([data-axis="y"]) .rt-carousel-controls.is-position-overlay {
+	padding-inline: var(--rt-carousel-control-inset, 0.5rem);
+}
+
+// Outside: add side gutters to the carousel so the slide viewport shrinks and
+// the edge-anchored arrows land beside (not over) the slides.
+.rt-carousel:not([data-axis="y"]):has(
+.rt-carousel-controls.is-position-outside
+) {
+	padding-inline: var(--rt-carousel-control-gutter, 3rem);
+}
+
+// Keep gutters usable on small screens.
+@media (max-width: 600px) {
+
+	.rt-carousel:not([data-axis="y"]):has(
+	.rt-carousel-controls.is-position-outside
+) {
+		padding-inline: var(--rt-carousel-control-gutter-mobile, 2.25rem);
+	}
+}

--- a/src/blocks/carousel/types.ts
+++ b/src/blocks/carousel/types.ts
@@ -33,7 +33,8 @@ export type CarouselViewportAttributes = Record<string, never>;
 export type CarouselSlideAttributes = {
 	verticalAlignment?: BlockVerticalAlignmentToolbar.Value;
 };
-export type CarouselControlsAttributes = Record<string, never>;
+export type CarouselControlsPosition = 'below' | 'overlay' | 'outside';
+export type CarouselControlsAttributes = { position: CarouselControlsPosition };
 export type CarouselDotsAttributes = Record<string, never>;
 export type CarouselProgressAttributes = Record<string, never>;
 export type CarouselCounterAttributes = Record<string, never>;


### PR DESCRIPTION
## Summary

Adds a **Position** option to the Carousel **Controls** block so the prev/next arrows can sit **Below** the slides (current default, unchanged), **Overlay** on the slide edges, or **Outside** flanking the slides. This is the common "arrows left/right of / over the cards" slider layout requested in #143.

The setting lives on the Controls block as a new `position` attribute, exposed via a `SelectControl` in the block inspector. A shared pure helper derives the wrapper class so `edit` and `save` can't drift, and CSS positions the arrows against the ancestor `.rt-carousel` (already `position: relative`), using `:has()` for the Outside gutter — the same `:has()` pattern already used for tabs mode.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement/refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Build/CI/tooling

## Related issue(s)

Closes #143

## What changed

- **New `position` attribute** (`below` default / `overlay` / `outside`) on `rt-carousel/carousel-controls` with a labelled **Position** `SelectControl` in the inspector (plus a hint to place Controls as a direct child of the carousel for overlay/outside).
- **Shared `getPositionClassName` helper** used by both `edit.tsx` and `save.tsx` → `below` emits only `rt-carousel-controls`; overlay/outside add `is-position-overlay` / `is-position-outside`.
- **CSS** (`controls/style.scss`): overlay floats arrows over the slide edges (absolute, vertically centered); outside adds side gutters via `:has()` so arrows flank the slides. Horizontal-only (`:not([data-axis="y"])`); RTL handled by existing logical-property + icon-flip rules. Tunable via `--rt-carousel-control-inset` / `--rt-carousel-control-gutter` / `--rt-carousel-control-gutter-mobile`. Overlay/outside also set `z-index: var(--rt-carousel-control-z, 1)` so the arrows reliably stack above slide content (Embla transforms the track, creating a stacking context) — added per review feedback.
- **Tests**: unit tests for the helper (4) and the editor control/class + back-compat + help-text (7).

## Breaking changes

- [ ] Yes — migration path:
- [x] No

Default is `below`, which is **not serialized** and emits **byte-identical markup** to the current output (`class="rt-carousel-controls"`, no modifier). Existing saved Controls blocks re-parse as valid — no block-validation errors, no deprecation entry, no forced re-save. New CSS activates only on the opt-in classes, so sites that just update the plugin look pixel-for-pixel the same.

## Testing

Describe how this was tested.

- [x] Unit tests
- [x] Manual testing (live editor + front end)
- [ ] Cross-browser testing (relies on `:has()` for the Outside gutter — already used by tabs mode; overlay does not use `:has()`)

Test details — run from the plugin root after checking out this branch:

```bash
npm ci
npm run build
npm run test:js          # 199 passing (10 suites)
npm run lint:js:types    # exit 0
npm run lint:css         # exit 0
```

Manual (in a WordPress editor): insert a Carousel → select the **Controls** block → set **Position** to **Overlay** then **Outside**, and verify on the front end:
- **Overlay** — arrows float over the left/right slide edges, vertically centered; slides remain clickable/draggable between them.
- **Outside** — arrows sit in side gutters, flanking the slides (not covering content).
- **Below** (default) — unchanged; an existing Controls block loads with no "unexpected content" warning.

Full step-by-step How-to-test lives on the issue: #143.

### Note on overlay centering

Overlay/outside arrows center on the slide **track** (`.rt-carousel` / viewport). If slide media carries a trailing margin — e.g. WordPress core/theme's `:where(figure){margin:0 0 1em}` on image slides — the track is taller than the visible media, so the arrows read as ~8px low. This is theme/content styling (the author controls it), **not** the feature's CSS, which adds no vertical margin/padding. Slides that fill their height (Cover blocks, vertically-centered content) don't show it.

## Screenshots / recordings

Verified on a local site with three carousels (below / overlay / outside); the compiled overlay/outside rules are served and applied on the front end. (Local dev env — no public URL to link.)

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added/updated tests where needed
- [ ] I have updated docs where needed <!-- no user-facing docs change; behavior is additive and opt-in -->
- [x] I have checked for breaking changes

